### PR TITLE
Few improvements to sparse module

### DIFF
--- a/tatva/sparse/__init__.py
+++ b/tatva/sparse/__init__.py
@@ -6,12 +6,12 @@ from ._coloring import (
 from ._extraction import (
     create_sparsity_pattern,
     create_sparsity_pattern_KKT,
+    create_sparsity_pattern_master_slave,
     get_bc_indices,
     reduce_sparsity_pattern,
 )
 from .base import (
     jacfwd,
-    jacfwd_with_batch,
 )
 
 __all__ = [
@@ -19,9 +19,9 @@ __all__ = [
     "reduce_sparsity_pattern",
     "get_bc_indices",
     "create_sparsity_pattern_KKT",
+    "create_sparsity_pattern_master_slave",
     "distance2_colors",
     "smallest_last_distance2_colors",
     "largest_degree_first_distance2_colors",
     "jacfwd",
-    "jacfwd_with_batch",
 ]

--- a/tatva/sparse/base.py
+++ b/tatva/sparse/base.py
@@ -66,48 +66,6 @@ def colored_jacobian_batch(
     return J_rows.T
 
 
-@partial(jax.jit, static_argnames=["F", "n_colors"])
-def colored_jacobian(
-    F: Callable,
-    x: Array,
-    colors: Array,
-    args: Tuple[Any, ...],
-    kwargs: Dict[str, Any],
-    n_colors: int,
-) -> Array:
-    """
-    Computes the compressed Jacobian using forward-mode AD and graph coloring without batching.
-    Reconstructs seeds on-the-fly via masking to avoid OOM and jagged arrays.
-    Args:
-        F: function to differentiate
-        x: Point at which to evaluate the Jacobian, shape (N,)
-        colors: Array of colors assigned to each DOF
-        args: Positional arguments to pass to F
-        kwargs: Keyword arguments to pass to F
-        n_colors: Number of unique colors
-    Returns:
-        J: Compressed Jacobian matrix, shape (N, n_colors)
-    """
-
-    def scan_body(carry, color_id):
-        # Generate seed for the current color_id on-the-fly
-        # seed = (colors == color_id)
-        seed = jnp.where(colors == color_id, 1.0, 0.0)
-
-        # Compute JVP
-        def F_x_only(u):
-            return F(u, *args, **kwargs)
-
-        _, jvp_out = jax.jvp(F_x_only, (x,), (seed,))
-
-        return None, jvp_out
-
-    color_ids = jnp.arange(n_colors)
-    _, J_columns = jax.lax.scan(scan_body, None, color_ids)
-
-    return J_columns.T  # Final shape (N_dof, n_colors)
-
-
 @partial(jax.jit, static_argnames=["n_dofs"])
 def recover_stiffness_matrix(
     J_compressed: Array,
@@ -147,13 +105,12 @@ def recover_stiffness_matrix(
     return K_bcoo
 
 
-def jacfwd_with_batch(
+def jacfwd(
     gradient: Callable,
     row_ptr: Array,
     col_indices: Array,
     colors: Array,
-    color_batch_size: int = 1,
-    has_aux_args: bool = False,
+    color_batch_size: int = 10,
 ) -> Callable:
     """
     Compute the sparse Jacobian using forward-mode automatic differentiation and graph coloring and provided seeds.
@@ -165,98 +122,21 @@ def jacfwd_with_batch(
         seeds: List of seed vectors for each color
         colors: The array of colors used for compression
         color_batch_size: Number of colors to process in each batch (1 for minimal memory usage, >1 for faster computation but higher memory)
-        has_aux_args: Whether the gradient function has auxiliary arguments.
-                      If True, the returned function will expect additional arguments after 'u'.
+        By default, 10 colors are processed.
     Returns:
         A function that computes the sparse Jacobian in BCOO format
     """
 
     n_colors = len(jnp.unique(colors)) + 1
 
-    if not has_aux_args:
+    def _wraped_jacfwd_with_args(u: Array, *args: Any, **kwargs: Any) -> jsp.BCOO:
+        # Pass args explicitly to the JIT-compiled function
+        J_compressed = colored_jacobian_batch(
+            gradient, u, colors, args, kwargs, n_colors, color_batch_size
+        )
+        n_dofs = J_compressed.shape[0]
+        return recover_stiffness_matrix(
+            J_compressed, row_ptr, col_indices, colors, n_dofs
+        )
 
-        def _wraped_jacfwd(u: Array) -> jsp.BCOO:
-            # Pass an empty tuple for args
-            J_compressed = colored_jacobian_batch(
-                gradient, u, colors, (), {}, n_colors, color_batch_size
-            )
-            n_dofs = J_compressed.shape[0]
-            return recover_stiffness_matrix(
-                J_compressed, row_ptr, col_indices, colors, n_dofs
-            )
-
-        return _wraped_jacfwd
-
-    if has_aux_args:
-
-        def _wraped_jacfwd_with_args(u: Array, *args: Any, **kwargs: Any) -> jsp.BCOO:
-            # Pass args explicitly to the JIT-compiled function
-            J_compressed = colored_jacobian_batch(
-                gradient, u, colors, args, kwargs, n_colors, color_batch_size
-            )
-            n_dofs = J_compressed.shape[0]
-            return recover_stiffness_matrix(
-                J_compressed, row_ptr, col_indices, colors, n_dofs
-            )
-
-        return _wraped_jacfwd_with_args
-
-
-def jacfwd(
-    gradient: Callable,
-    row_ptr: Array,
-    col_indices: Array,
-    colors: Array,
-    has_aux_args: bool = False,
-) -> Callable:
-    """
-    Compute the sparse Jacobian using forward-mode automatic differentiation and graph coloring.
-    The seeds are reconstructed on-the-fly to save memory. Use jax.lax.scan to iterate over colors
-    without materializing the entire compressed Jacobian in memory at once.
-
-    Args:
-        gradient: Function whose Jacobian is to be computed
-        row_ptr, col_indices: The sparsity pattern of the matrix
-        colors: The array of colors used for compression
-        has_aux_args: Whether the gradient function has auxiliary arguments.
-                     If True, the returned function will expect additional arguments after 'u'.
-    Returns:
-        A function that computes the sparse Jacobian in BCOO format
-
-    """
-    n_colors = len(jnp.unique(colors)) + 1
-
-    if not has_aux_args:
-
-        def _wraped_jacfwd(u: Array) -> jsp.BCOO:
-            J_compressed = colored_jacobian(
-                gradient, x=u, colors=colors, args=(), kwargs={}, n_colors=int(n_colors)
-            )
-            n_dofs = J_compressed.shape[0]
-
-            K_bcoo = recover_stiffness_matrix(
-                J_compressed, row_ptr, col_indices, colors, n_dofs
-            )
-            return K_bcoo
-
-        return _wraped_jacfwd
-    if has_aux_args:
-
-        def _wraped_jacfwd_with_args(u: Array, *args: Any, **kwargs: Any) -> jsp.BCOO:
-
-            J_compressed = colored_jacobian(
-                gradient,
-                x=u,
-                colors=colors,
-                args=args,
-                kwargs=kwargs,
-                n_colors=int(n_colors),
-            )
-            n_dofs = J_compressed.shape[0]
-
-            K_bcoo = recover_stiffness_matrix(
-                J_compressed, row_ptr, col_indices, colors, n_dofs
-            )
-            return K_bcoo
-
-        return _wraped_jacfwd_with_args
+    return _wraped_jacfwd_with_args

--- a/tests/test_sparse_benchmark.py
+++ b/tests/test_sparse_benchmark.py
@@ -110,22 +110,20 @@ def test_sparse_benchmark(nx, ny):
         _build_problem(nx=nx, ny=ny)
     )
 
-    hessian_sparse_with_args = sparse.jacfwd_with_batch(
+    hessian_sparse_with_args = sparse.jacfwd(
         gradient=jax.jacrev(total_energy_with_args, argnums=0),
         row_ptr=jnp.array(sparsity_pattern_csr.indptr),
         col_indices=jnp.array(sparsity_pattern_csr.indices),
         colors=jnp.array(colors),
         color_batch_size=10,  # Batch size for evaluating the element routine
-        has_aux_args=True,  # Whether the gradient function has auxiliary arguments (x, y, damage, etc.)
     )
 
-    hessian_sparse = sparse.jacfwd_with_batch(
+    hessian_sparse = sparse.jacfwd(
         gradient=jax.jacrev(total_energy, argnums=0),
         row_ptr=jnp.array(sparsity_pattern_csr.indptr),
         col_indices=jnp.array(sparsity_pattern_csr.indices),
         colors=jnp.array(colors),
         color_batch_size=10,  # Batch size for evaluating the element routine
-        has_aux_args=False,  # Whether the gradient function has auxiliary arguments (x, y, damage, etc.)
     )
 
     u_flat = jnp.zeros(op.mesh.coords.shape[0] * 2)  # Initial guess for displacements


### PR DESCRIPTION
- Removes duplicate code for  `jacfwd` with color batch and without color batch. Now a single `sparse.jacfwd` with `jax.lax.map` by default to batch over colors. This was the default used for the performance analysis in the paper.
- Removes conditional handling of with `args` and without args inside `sparse.jacfwd`. Now a single implementation that works for both cases.
- Pass `args` and `kwargs` for a function to be sparsely differentiated directly to jitted colored jacobian. Improve performance by not recompling the `wrapped_func` on every call when called with args.
- Add `test_sparse_benchmark` to quickly check the efficiency of `sparse.jacfwd` with and without args. Ideally the computation time should be similar.
- Allows `create_sparsity_pattern_master_slave` to be imported as `sparse.create_sparsity_pattern_master_slave` instead of `sparse._extraction.create_sparsity_pattern_master_slave`.