### PR TITLE
Allow specifying argnum to differentiate wrt to

### DIFF
--- a/tatva/compound/__init__.py
+++ b/tatva/compound/__init__.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import replace
 from math import prod
 from typing import (
     TYPE_CHECKING,
@@ -41,7 +40,6 @@ from tatva.compound.field import (
     Field,
     FieldSize,
     FieldStackedView,
-    FieldType,
     _FieldBase,
     _FieldSpec,
     field,
@@ -145,35 +143,11 @@ class Compound:
         # field is defined on all nodes of the mesh and can be stacked together
         other_specs: list[tuple[str, _FieldSpec]] = []
 
-        from tatva.compound.field_types import Nodal
-
         for name, spec in new_specs:
             ft_obj = spec.field_type.get()
+            spec, should_stack = ft_obj.resolve_spec(spec, mesh)
 
-            if _is_auto_nodal(spec):
-                # if the first dimension is AUTO, we set it to Nodal, and resolve the
-                # shape to be (num_items, *rest).
-                if isinstance(ft_obj, Nodal) and ft_obj.node_ids is not None:
-                    n_items_field = len(ft_obj.node_ids)
-                else:
-                    if mesh is None:
-                        raise CompoundError(
-                            f"Mesh must be provided to resolve AUTO size for field '{name}'."
-                        )
-                    n_items_field = mesh.coords.shape[0]
-
-                spec = replace(
-                    spec,
-                    shape=(n_items_field, *spec.shape[1:]),
-                    field_type=ft_obj if isinstance(ft_obj, Nodal) else FieldType.NODAL,
-                )
-
-            field_type_obj = spec.field_type.get()
-            if (
-                isinstance(field_type_obj, Nodal)
-                and (field_type_obj.node_ids is None)
-                and field_type_obj.stack
-            ):
+            if should_stack:
                 full_nodal_specs.append((name, spec))
             else:
                 other_specs.append((name, spec))

--- a/tatva/compound/field.py
+++ b/tatva/compound/field.py
@@ -18,24 +18,19 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import IntEnum
 from math import prod
 from typing import TYPE_CHECKING, Callable, Self, TypeVar, overload
 
 import jax.numpy as jnp
 from jax import Array
 
-from tatva.compound.field_types import FieldType, _FieldType
+from tatva.compound.field_types import FieldSize, FieldType, _FieldType
 
 if TYPE_CHECKING:
     from tatva.compound import Compound
 
 
 T_Compound = TypeVar("T_Compound", bound="Compound")
-
-
-class FieldSize(IntEnum):
-    AUTO = -1
 
 
 @dataclass(frozen=True)

--- a/tatva/compound/field_types.py
+++ b/tatva/compound/field_types.py
@@ -17,17 +17,79 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import IntEnum
-from typing import Self
+from math import prod
+from typing import TYPE_CHECKING, Self
 
+import numpy as np
+import scipy.sparse as sps
 from jax import Array
 from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from tatva.compound.field import Field, _FieldSpec
+    from tatva.mesh import Mesh
+
+
+class FieldSize(IntEnum):
+    AUTO = -1
 
 
 class _FieldType:
     def get(self) -> Self:
         return self
+
+    def resolve_spec(
+        self, spec: _FieldSpec, mesh: Mesh | None
+    ) -> tuple[_FieldSpec, bool]:
+        if len(spec.shape) > 0 and spec.shape[0] == FieldSize.AUTO:
+            # Fallback: if AUTO is used but type is not specialized, we default to Nodal
+            # This preserves the behavior of the existing tests.
+            return Nodal().resolve_spec(spec, mesh)
+        return spec, False
+
+    def get_element_dofs(self, field: Field, mesh: Mesh) -> NDArray | None:
+        return None
+
+    def get_diagonal_dofs(self, field: Field, mesh: Mesh) -> NDArray | None:
+        return None
+
+    def get_coupling_block(
+        self, this: Field, other: Field, mesh: Mesh
+    ) -> sps.csr_matrix:
+        """Returns the sparsity pattern of the coupling between two fields."""
+        edofs_this = self.get_element_dofs(this, mesh)
+        other_type = other.field_type.get()
+        edofs_other = other_type.get_element_dofs(other, mesh)
+
+        if edofs_this is not None and edofs_other is not None:
+            row_indices = np.repeat(edofs_this, edofs_other.shape[1], axis=1).flatten()
+            col_indices = np.tile(edofs_other, (1, edofs_this.shape[1])).flatten()
+
+            # Filter out -1
+            valid = (row_indices >= 0) & (col_indices >= 0)
+            row_indices = row_indices[valid]
+            col_indices = col_indices[valid]
+        elif this is other:
+            row_indices = self.get_diagonal_dofs(this, mesh)
+            if row_indices is None:
+                return sps.csr_matrix((this.size, other.size), dtype=np.int8)
+            col_indices = row_indices
+        else:
+            return sps.csr_matrix((this.size, other.size), dtype=np.int8)
+
+        # Make relative to field base
+        row_indices = row_indices - this._base_offset
+        col_indices = col_indices - other._base_offset
+
+        data = np.ones(row_indices.shape[0], dtype=np.int8)
+        return sps.csr_matrix(
+            (data, (row_indices, col_indices)), shape=(this.size, other.size)
+        )
+
+    def get_sparsity_pattern(self, field: Field, mesh: Mesh) -> sps.csr_matrix:
+        return self.get_coupling_block(field, field, mesh)
 
 
 @dataclass
@@ -35,15 +97,61 @@ class Nodal(_FieldType):
     node_ids: Array | NDArray | None = None
     stack: bool = True
 
+    def resolve_spec(
+        self, spec: _FieldSpec, mesh: Mesh | None
+    ) -> tuple[_FieldSpec, bool]:
+        if len(spec.shape) > 0 and spec.shape[0] == FieldSize.AUTO:
+            if mesh is None:
+                raise ValueError(
+                    "Mesh must be provided when using AUTO shape with Nodal field type."
+                )
+            if self.node_ids is not None:
+                n_items = len(self.node_ids)
+            else:
+                n_items = mesh.coords.shape[0]
+            shape = (n_items, *spec.shape[1:])
+        else:
+            shape = spec.shape
+
+        spec = replace(spec, shape=shape, field_type=self)
+        should_stack = self.stack and self.node_ids is None
+        return spec, should_stack
+
+    def get_element_dofs(self, field: Field, mesh: Mesh) -> NDArray | None:
+        n_nodes = mesh.coords.shape[0]
+        num_elements = mesh.elements.shape[0]
+        indices = np.asarray(field.indices(slice(None)))
+
+        n_items = len(self.node_ids) if self.node_ids is not None else n_nodes
+
+        if n_items == 0:
+            return None
+
+        dofs_per_item = indices.size // n_items
+        node_dofs = np.full((n_nodes, dofs_per_item), -1, dtype=np.int32)
+        if self.node_ids is None:
+            node_dofs[:] = indices.reshape(n_nodes, dofs_per_item)
+        else:
+            node_ids = np.asarray(self.node_ids, dtype=np.int32)
+            valid_nodes = (node_ids >= 0) & (node_ids < n_nodes)
+            node_dofs[node_ids[valid_nodes]] = indices.reshape(-1, dofs_per_item)[
+                valid_nodes
+            ]
+
+        # Map nodes to elements
+        return node_dofs[mesh.elements].reshape(num_elements, -1)
+
 
 @dataclass
 class Local(_FieldType):
-    pass
+    def get_diagonal_dofs(self, field: Field, mesh: Mesh) -> NDArray | None:
+        return np.asarray(field.indices(slice(None))).flatten()
 
 
 @dataclass
 class Shared(_FieldType):
-    pass
+    def get_diagonal_dofs(self, field: Field, mesh: Mesh) -> NDArray | None:
+        return np.asarray(field.indices(slice(None))).flatten()
 
 
 class FieldType(IntEnum):
@@ -63,3 +171,34 @@ _enum_to_class: dict[FieldType, type[_FieldType]] = {
     FieldType.SHARED: Shared,
     FieldType.NODAL: Nodal,
 }
+
+
+@dataclass
+class CG1(Nodal):
+    submesh: Mesh | None = None
+
+
+@dataclass
+class DG0(Local):
+    def resolve_spec(
+        self, spec: _FieldSpec, mesh: Mesh | None
+    ) -> tuple[_FieldSpec, bool]:
+        if len(spec.shape) > 0 and spec.shape[0] == FieldSize.AUTO:
+            if mesh is None:
+                raise ValueError(
+                    "Mesh must be provided when using AUTO shape with DG0 field type."
+                )
+            shape = (mesh.elements.shape[0], *spec.shape[1:])
+        else:
+            shape = spec.shape
+
+        spec = replace(spec, shape=shape, field_type=self)
+        return spec, False
+
+    def get_element_dofs(self, field: Field, mesh: Mesh) -> NDArray | None:
+        indices = np.asarray(field.indices(slice(None)))
+        num_elements = mesh.elements.shape[0]
+        return indices.reshape(num_elements, -1)
+
+    def get_diagonal_dofs(self, field: Field, mesh: Mesh) -> NDArray | None:
+        return None

--- a/tatva/operator.py
+++ b/tatva/operator.py
@@ -108,6 +108,9 @@ class Operator(Generic[ElementT]):
     element: ElementT = field(metadata=dict(static=True))
     batch_size: int | None = field(metadata=dict(static=True), default=None)
     cache_weights: bool = field(metadata=dict(static=True), default=False)
+    _det_J_elements_weights: jax.Array | None = field(
+        repr=False, compare=False, default=None, kw_only=True
+    )
 
     def __post_init__(self) -> None:
         # run initialization checks to ensure mesh/element compatibility and basic
@@ -178,10 +181,10 @@ class Operator(Generic[ElementT]):
             A `jax.Array` with the integration weights at each quadrature point of each
             element (shape: (n_elements, n_quad_points)).
         """
-        if self.cache_weights:
+        if self.cache_weights and self._det_J_elements_weights is not None:
             # if cache_weights is True, we have computed the integration weights in
             # __post_init__ and stored them in _det_J_elements_weights
-            return self._det_J_elements_weights  # pyright: ignore[reportAttributeAccessIssue]
+            return self._det_J_elements_weights
         else:
 
             def _get_det_J(xi: jax.Array, el_nodal_coords: jax.Array) -> jax.Array:

--- a/tatva/operator.py
+++ b/tatva/operator.py
@@ -399,6 +399,25 @@ class Operator(Generic[ElementT]):
 
         return self._vmap_over_elements_and_quads(nodal_values, _gradient_quad)
 
+    def div(self, nodal_values: jax.Array) -> jax.Array:
+        """Computes the divergence of the nodal values at the quad points.
+
+        Args:
+            nodal_values: The nodal values at the element's nodes (shape: (n_nodes, n_values))
+
+        Returns:
+            A `jax.Array` with the divergence of the nodal values at each quadrature point
+            of each element (shape: (n_elements, n_quad_points, n_values)).
+        """
+        if nodal_values.ndim < 2 or nodal_values.shape[1] <= 1:
+            raise ValueError(
+                "Cannot compute divergence for a scalar field. "
+                "Nodal values must have at least 2 dimensions to compute divergence. "
+                f"Got shape: {nodal_values.shape}; Expected shape (n_nodes, *n_values)."
+            )
+        grad = self.grad(nodal_values)
+        return jnp.einsum("n...ii->n...", grad)
+
     def interpolate(self, arg: jax.Array, points: jax.Array) -> jax.Array:
         """Interpolates nodal values to a set of points in the physical space.
 

--- a/tatva/sparse/_extraction.py
+++ b/tatva/sparse/_extraction.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -298,8 +297,9 @@ def create_sparsity_pattern_from_compound(
     """Create a sparsity pattern automatically from a Compound class and its attached
     mesh.
 
-    Nodal fields are fully coupled within elements. All other fields (Local, Shared)
-    are only connected to themselves (diagonal entries).
+    Fields that provide element DOFs (via field_type.get_element_dofs) are fully coupled
+    within elements. All other fields (Local, Shared) are only connected to themselves
+    (diagonal entries).
 
     Args:
         compound_cls: The Compound class defining the state layout.
@@ -307,49 +307,19 @@ def create_sparsity_pattern_from_compound(
         block_wise: If True, return the pattern as a list of lists of sparse matrices
             corresponding to the compound fields/blocks. Stacked fields are one block.
     """
-    from tatva.compound.field_types import Nodal
-
-    n_nodes = mesh.coords.shape[0]
-    num_elements = mesh.elements.shape[0]
-
     main_coupling_list: list[NDArray[np.int32]] = []
     diagonal_dofs_list: list[NDArray[np.int32]] = []
 
     for name, f in compound_cls.fields:
         field_type_obj = f.field_type.get()
-        if isinstance(field_type_obj, Nodal):
-            # Map field DOFs to nodes
-            indices = np.asarray(f.indices(slice(None)))
-            n_items = (
-                len(field_type_obj.node_ids)
-                if field_type_obj.node_ids is not None
-                else n_nodes
-            )
 
-            if n_items > 0:
-                dofs_per_item = indices.size // n_items
+        edofs = field_type_obj.get_element_dofs(f, mesh)
+        if edofs is not None:
+            main_coupling_list.append(edofs)
 
-                node_dofs = np.full((n_nodes, dofs_per_item), -1, dtype=np.int32)
-                if field_type_obj.node_ids is None:
-                    node_dofs[:] = indices.reshape(n_nodes, dofs_per_item)
-                else:
-                    node_ids = np.asarray(field_type_obj.node_ids, dtype=np.int32)
-                    valid_nodes = (node_ids >= 0) & (node_ids < n_nodes)
-                    node_dofs[node_ids[valid_nodes]] = indices.reshape(
-                        -1, dofs_per_item
-                    )[valid_nodes]
-
-                # Map nodes to elements
-                f_element_dofs = node_dofs[mesh.elements].reshape(num_elements, -1)
-                main_coupling_list.append(f_element_dofs)
-        else:
-            warnings.warn(
-                f"Custom space detected for field '{name}'. Only diagonal entries added "
-                "to the sparsity pattern. Please provide your own sparsity pattern if "
-                "cross-coupling is required.",
-                UserWarning,
-            )
-            diagonal_dofs_list.append(np.asarray(f.indices(slice(None))).flatten())
+        ddofs = field_type_obj.get_diagonal_dofs(f, mesh)
+        if ddofs is not None:
+            diagonal_dofs_list.append(ddofs)
 
     K_shape = (compound_cls.size, compound_cls.size)
     all_rows = []

--- a/tests/test_refactored_sparsity.py
+++ b/tests/test_refactored_sparsity.py
@@ -1,0 +1,148 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import scipy.sparse as sps
+
+from tatva.compound import Compound, field
+from tatva.compound.field_types import CG1, DG0, Nodal
+from tatva.mesh import Mesh
+
+jax.config.update("jax_enable_x64", True)
+
+def test_cg1_sparsity_pattern():
+    # 2x2 nodes, 2 triangles
+    coords = jnp.array([[0,0], [1,0], [0,1], [1,1]], dtype=float)
+    elements = jnp.array([[0,1,3], [0,3,2]], dtype=int)
+    mesh = Mesh(coords=coords, elements=elements)
+
+    class State(Compound, mesh=mesh):
+        u = field((4,), field_type=CG1())
+
+    sparsity = State.get_sparsity()
+    
+    # Check that it's a CSR matrix
+    assert isinstance(sparsity, sps.csr_matrix)
+    assert sparsity.shape == (4, 4)
+    
+    # Connectivity:
+    # Element 0: (0,1,3) -> couplings (0,0),(0,1),(0,3),(1,0),(1,1),(1,3),(3,0),(3,1),(3,3)
+    # Element 1: (0,3,2) -> couplings (0,0),(0,3),(0,2),(3,0),(3,3),(3,2),(2,0),(2,3),(2,2)
+    
+    # Expected non-zeros (sorted):
+    # Row 0: 0, 1, 2, 3
+    # Row 1: 0, 1, 3
+    # Row 2: 0, 2, 3
+    # Row 3: 0, 1, 2, 3
+    
+    expected_nonzeros = [
+        (0,0), (0,1), (0,2), (0,3),
+        (1,0), (1,1), (1,3),
+        (2,0), (2,2), (2,3),
+        (3,0), (3,1), (3,2), (3,3)
+    ]
+    
+    actual_nonzeros = list(zip(*sparsity.nonzero()))
+    assert set(actual_nonzeros) == set(expected_nonzeros)
+
+def test_mixed_cg1_dg0_sparsity():
+    coords = jnp.array([[0,0], [1,0], [0,1], [1,1]], dtype=float)
+    elements = jnp.array([[0,1,3], [0,3,2]], dtype=int)
+    mesh = Mesh(coords=coords, elements=elements)
+
+    class StokesState(Compound, mesh=mesh):
+        u = field((4,), field_type=CG1())
+        p = field((2,), field_type=DG0())
+
+    # Total size: 4 (u) + 2 (p) = 6
+    assert StokesState.size == 6
+    
+    sparsity = StokesState.get_sparsity()
+    assert sparsity.shape == (6, 6)
+    
+    # Check coupling between u and p
+    # Element 0: nodes (0,1,3), p-index 0 (global index 4)
+    # Element 1: nodes (0,3,2), p-index 1 (global index 5)
+    
+    # Couplings for Element 0:
+    # (0,4), (1,4), (3,4) and (4,0), (4,1), (4,3)
+    # Couplings for Element 1:
+    # (0,5), (3,5), (2,5) and (5,0), (5,3), (5,2)
+    
+    assert sparsity[0, 4] == 1
+    assert sparsity[1, 4] == 1
+    assert sparsity[3, 4] == 1
+    assert sparsity[4, 0] == 1
+    assert sparsity[4, 1] == 1
+    assert sparsity[4, 3] == 1
+    
+    assert sparsity[0, 5] == 1
+    assert sparsity[3, 5] == 1
+    assert sparsity[2, 5] == 1
+    assert sparsity[5, 0] == 1
+    assert sparsity[5, 3] == 1
+    assert sparsity[5, 2] == 1
+    
+    # Check that p is diagonal with itself (since DG0 only couples within element, and there's only 1 DOF per element)
+    assert sparsity[4, 4] == 1
+    assert sparsity[5, 5] == 1
+    assert sparsity[4, 5] == 0
+    assert sparsity[5, 4] == 0
+
+def test_block_wise_sparsity():
+    coords = jnp.array([[0,0], [1,0], [0,1], [1,1]], dtype=float)
+    elements = jnp.array([[0,1,3], [0,3,2]], dtype=int)
+    mesh = Mesh(coords=coords, elements=elements)
+
+    class State(Compound, mesh=mesh):
+        u = field((4,), field_type=CG1())
+        p = field((2,), field_type=DG0())
+
+    blocks = State.get_sparsity(block_wise=True)
+    assert len(blocks) == 2
+    assert len(blocks[0]) == 2
+    
+    K_uu = blocks[0][0]
+    K_up = blocks[0][1]
+    K_pu = blocks[1][0]
+    K_pp = blocks[1][1]
+    
+    assert K_uu.shape == (4, 4)
+    assert K_up.shape == (4, 2)
+    assert K_pu.shape == (2, 4)
+    assert K_pp.shape == (2, 2)
+    
+    # Check K_up entries
+    assert K_up[0, 0] == 1
+    assert K_up[1, 0] == 1
+    assert K_up[3, 0] == 1
+    assert K_up[0, 1] == 1
+    assert K_up[3, 1] == 1
+    assert K_up[2, 1] == 1
+    
+    # K_pp should be identity
+    assert np.all(K_pp.toarray() == np.eye(2))
+
+def test_get_coupling_block_direct():
+    coords = jnp.array([[0,0], [1,0], [0,1], [1,1]], dtype=float)
+    elements = jnp.array([[0,1,3], [0,3,2]], dtype=int)
+    mesh = Mesh(coords=coords, elements=elements)
+
+    class State(Compound, mesh=mesh):
+        u = field((4,), field_type=CG1())
+        p = field((2,), field_type=DG0())
+        
+    u_field = State.u
+    p_field = State.p
+    
+    K_up = CG1().get_coupling_block(u_field, p_field, mesh)
+    assert K_up.shape == (4, 2)
+    assert K_up[0, 0] == 1
+    assert K_up[1, 0] == 1
+    assert K_up[3, 0] == 1
+    assert K_up[0, 1] == 1
+    assert K_up[3, 1] == 1
+    assert K_up[2, 1] == 1
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
adds `argnums=0` to `sparse.jacfwd` to specify primal vector argument