### PR TITLE
adds linearized jacfwd with primal output

### DIFF
--- a/tatva/sparse/__init__.py
+++ b/tatva/sparse/__init__.py
@@ -10,7 +10,7 @@ from ._extraction import (
     get_bc_indices,
     reduce_sparsity_pattern,
 )
-from .base import ColoredMatrix, jacfwd
+from .base import ColoredMatrix, jacfwd, linearized_jacfwd
 
 __all__ = [
     "create_sparsity_pattern",
@@ -23,4 +23,5 @@ __all__ = [
     "largest_degree_first_distance2_colors",
     "ColoredMatrix",
     "jacfwd",
+    "linearized_jacfwd",
 ]

--- a/tatva/sparse/base.py
+++ b/tatva/sparse/base.py
@@ -105,6 +105,37 @@ class ColoredMatrix:
         return bcoo.todense()
 
 
+@jax.jit
+def compute_rows_cols(colored_matrix: ColoredMatrix) -> tuple[Array, Array]:
+    """Helper function to compute the row and column indices for a sparse matrix in CSR format.
+    This is used to recover the full Jacobian from the compressed version after graph coloring.
+
+    Args:
+        colored_matrix: ColoredMatrix containing the CSR data
+
+    Returns:
+        rows: Array of row indices for each non-zero entry in the sparse matrix.
+        cols: Array of column indices for each non-zero entry in the sparse matrix.
+    """
+
+    _indptr = colored_matrix.indptr
+    _indices = colored_matrix.indices
+    _colors = colored_matrix.colors
+    # precompute the indices needed to recover the full Jacobian from the compressed version
+    # rows: row index per non-zero entry (length nnz)
+    diffs = jnp.diff(_indptr)
+    rows = jnp.repeat(
+        jnp.arange(_indptr.shape[0] - 1),
+        diffs,
+        total_repeat_length=_indices.shape[0],
+    )
+    # find where the value for (i, j) is hiding in J_compressed
+    # The value K_ij is stored at row 'i' and column 'color[j]'
+    # col_colors: color of the column for each non-zero entry (length nnz)
+    col_colors = _colors[_indices]
+    return rows, col_colors
+
+
 def jacfwd(
     fn: Callable[Concatenate[Array, P], Array],
     colored_matrix: ColoredMatrix,
@@ -124,37 +155,76 @@ def jacfwd(
         color_batch_size: Optional batch size for processing colors. If None, processes
             all colors at once. If memory usage is a concern, set to a smaller value to
             process colors in batches.
+
+    Returns:
+        A function that computes the sparse Jacobian of `fn` at a given input, returning
+        a new instance of `ColoredMatrix` containing the Jacobian values in the `data` field.
     """
     nb_colors = int(colored_matrix.colors.max()) + 1
     if color_batch_size is None:
         color_batch_size = nb_colors
 
-    _indptr = colored_matrix.indptr
-    _indices = colored_matrix.indices
-    _colors = colored_matrix.colors
-    # precompute the indices needed to recover the full Jacobian from the compressed version
-    # rows: row index per non-zero entry (length nnz)
-    diffs = jnp.diff(_indptr)
-    rows = jnp.repeat(
-        jnp.arange(_indptr.shape[0] - 1),
-        diffs,
-        total_repeat_length=_indices.shape[0],
-    )
-    # find where the value for (i, j) is hiding in J_compressed
-    # The value K_ij is stored at row 'i' and column 'color[j]'
-    # col_colors: color of the column for each non-zero entry (length nnz)
-    col_colors = _colors[_indices]
+    rows, col_colors = compute_rows_cols(colored_matrix)
 
     def _wrapped_jacfwd(u: Array, *args: P.args, **kwargs: P.kwargs) -> ColoredMatrix:
         J_compressed = colored_jacobian_batch(
             fn, u, colored_matrix.colors, nb_colors, color_batch_size, *args, **kwargs
         )
-        # TODO: this function is a one-liner, could do here directly:
-        # data = J_compressed[rows, col_colors]
-        data = recover_matrix_data(J_compressed, rows, col_colors)
+        data = J_compressed[rows, col_colors]
         return replace(colored_matrix, data=data)
 
     return _wrapped_jacfwd
+
+
+def linearized_jacfwd(
+    fn: Callable[Concatenate[Array, P], Array],
+    colored_matrix: ColoredMatrix,
+    *,
+    color_batch_size: int | None = None,
+) -> Callable[Concatenate[Array, P], tuple[Array, ColoredMatrix]]:
+    """Like sparse.jacfwd but uses jax.linearize to avoid redundant forward passes.
+    In general that means the memory usage scales with size of the computation.
+
+    Args:
+        fn: Function for which to compute the Jacobian. Must take an Array as its first
+            argument and return an Array. Will be differentiated with respect to the first
+            argument.
+        colored_matrix: An instance of ColoredMatrix representing the sparsity pattern and
+            coloring of the Jacobian.
+        color_batch_size: Optional batch size for processing colors. If None, processes
+            all colors at once. If memory usage is a concern, set to a smaller value to
+            process colors in batches.
+
+    Returns:
+        a function that computes both the primal values and the sparse Jacobian in a single
+        call, sharing the forward pass.
+    """
+    nb_colors = int(colored_matrix.colors.max()) + 1
+    if color_batch_size is None:
+        color_batch_size = nb_colors
+
+    rows, col_colors = compute_rows_cols(colored_matrix)
+
+    def _wrapped_linearized(u, *args, **kwargs):
+
+        def f(u):
+            return fn(u, *args, **kwargs)
+
+        primals_out, fn_linear = jax.linearize(f, u)
+
+        def compute_single_jvp(color_id):
+            seed = jnp.where(colored_matrix.colors == color_id, 1.0, 0.0)
+            return fn_linear(seed)
+
+        colors_array = jnp.arange(nb_colors)
+        J_compressed = jax.lax.map(
+            compute_single_jvp, colors_array, batch_size=color_batch_size
+        ).T
+
+        data = J_compressed[rows, col_colors]
+        return primals_out, replace(colored_matrix, data=data)
+
+    return _wrapped_linearized
 
 
 @partial(jax.jit, static_argnames=["fn", "n_colors", "color_batch_size"])
@@ -170,6 +240,7 @@ def colored_jacobian_batch(
     """
     Computes the compressed Jacobian by processing colors in batches. By default,
     processes one color at a time to minimize memory usage.
+
     Args:
         fn: function to differentiate
         x: Point at which to evaluate the Jacobian, shape (N,)
@@ -178,12 +249,13 @@ def colored_jacobian_batch(
         color_batch_size: Number of colors to process in each batch
         *args: Positional arguments to pass to F
         **kwargs: Keyword arguments to pass to F
+
     Returns:
         J: Compressed Jacobian matrix, shape (N, n_colors)
     """
 
     def compute_single_jvp(color_id: Array):
-        # TODO: Can this be moved outside the loop? Precompute it when creating jacfwd?
+        # Cannot be moved outside the loop because of the constant folding issue
         seed = jnp.where(colors == color_id, 1.0, 0.0)
 
         def fn_partial(u: Array) -> Array:
@@ -192,25 +264,7 @@ def colored_jacobian_batch(
         _, jvp_out = jax.jvp(fn_partial, (x,), (seed,))
         return jvp_out
 
-    # TODO: Can this be moved outside the loop? Precompute it when creating jacfwd?
     colors_array = jnp.arange(n_colors)
     J_rows = jax.lax.map(compute_single_jvp, colors_array, batch_size=color_batch_size)
 
     return J_rows.T
-
-
-@jax.jit
-def recover_matrix_data(
-    J_compressed: Array, coo_rows: Array, col_colors: Array
-) -> Array:
-    """
-    Recover the exact values from the compressed Jacobian.
-
-    Args:
-        J_compressed: Output from colored_jacobian, shape (N, n_colors)
-        coo_rows: row index per non-zero entry (length nnz)
-        col_colors: color of the column for each non-zero entry (length nnz)
-    """
-    # extract values using fancy indexing
-    # values[k] = J_compressed[ rows[k], col_colors[k] ]
-    return J_compressed[coo_rows, col_colors]

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -4,9 +4,8 @@ import numpy as np
 import pytest
 from jax import Array
 from jax_autovmap import autovmap
-from tatva_coloring import distance2_color_and_seeds
-
 from tatva import Mesh, Operator, element, sparse
+from tatva_coloring import distance2_color_and_seeds
 
 jax.config.update("jax_enable_x64", True)
 
@@ -69,4 +68,12 @@ def test_sparse_matrix(op: Operator, coloring_func):
         jax.jacrev(total_energy), colored_matrix, color_batch_size=10
     )(jnp.zeros(op.mesh.coords.shape[0] * 2))
 
+    primal, K_linearized = sparse.linearized_jacfwd(
+        jax.jacrev(total_energy), colored_matrix, color_batch_size=10
+    )(jnp.zeros(op.mesh.coords.shape[0] * 2))
+
     np.testing.assert_allclose(K, K_sparse.to_dense())
+    np.testing.assert_allclose(K, K_linearized.to_dense())
+    np.testing.assert_allclose(
+        primal, jax.grad(total_energy)(jnp.zeros(op.mesh.coords.shape[0] * 2))
+    )

--- a/tests/test_sparse_benchmark.py
+++ b/tests/test_sparse_benchmark.py
@@ -111,12 +111,14 @@ def test_sparse_benchmark(nx, ny):
         colored_matrix=colored_matrix,
         color_batch_size=10,  # Batch size for evaluating the element routine
     )
+    hessian_sparse_with_args = jax.jit(hessian_sparse_with_args)
 
     hessian_sparse = sparse.jacfwd(
         fn=jax.jacrev(total_energy, argnums=0),
         colored_matrix=colored_matrix,
         color_batch_size=10,  # Batch size for evaluating the element routine
     )
+    hessian_sparse = jax.jit(hessian_sparse)
 
     u_flat = jnp.zeros(op.mesh.coords.shape[0] * 2)  # Initial guess for displacements
     damage = jnp.ones(op.mesh.coords.shape[0])  # Dummy damage variable for testing)


### PR DESCRIPTION
This PR adds the function `linearized_jacfwd` to the sparse module, which allows linearization of a function before doing multiple `jvp` calls to compute `ColoredJacobian`. 

This is beneficial in problems where the function is quite complex, for example, multiphysical problems, where we would not want to solve a RVE problem for every color pass.

The output signature of the wrapped function given by the `sparse.linearized_jacfwd`  returns `Array, ColoredMatrix`.