### PR TITLE
fix(element): corrects the gradient enteries

### DIFF
--- a/tatva/element/base.py
+++ b/tatva/element/base.py
@@ -19,6 +19,7 @@
 from abc import ABC, abstractmethod
 
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 
 
@@ -28,10 +29,6 @@ class Element(ABC):
 
     Elements are to be used as static objects only in jax transformations! Considered
     immutable. Do not mutate.
-
-    Currently, equality and hash are based on object identity, meaning two elements are
-    only equal if they are the same object in memory. Even if two elements have the same
-    type and quad rule.
     """
 
     quad_points: Array
@@ -52,6 +49,23 @@ class Element(ABC):
             self.quad_weights = quad_weights
         else:
             self.quad_points, self.quad_weights = self._default_quadrature()
+
+    def __eq__(self, other: object) -> bool:
+        if type(self) is not type(other):
+            return False
+        assert isinstance(other, Element)
+        return np.array_equal(self.quad_points, other.quad_points) and np.array_equal(
+            self.quad_weights, other.quad_weights
+        )
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                type(self),
+                np.array(self.quad_points).tobytes(),
+                np.array(self.quad_weights).tobytes(),
+            )
+        )
 
     @abstractmethod
     def _reference_nodes(self) -> Array:

--- a/tatva/element/base.py
+++ b/tatva/element/base.py
@@ -54,6 +54,11 @@ class Element(ABC):
             self.quad_points, self.quad_weights = self._default_quadrature()
 
     @abstractmethod
+    def _reference_nodes(self) -> Array:
+        """Returns reference nodes for this element"""
+        raise NotImplementedError
+
+    @abstractmethod
     def _default_quadrature(self) -> tuple[Array, Array]:
         """Returns the default quadrature points and weights for this element."""
         raise NotImplementedError
@@ -81,7 +86,7 @@ class Element(ABC):
         dNdr = self.shape_function_derivative(xi)
         J, _ = self.get_jacobian(xi, nodal_coords)
         dNdX = jnp.linalg.inv(J) @ dNdr
-        return dNdX @ nodal_values
+        return (dNdX @ nodal_values).T
 
     def get_local_values(
         self, xi: Array, nodal_values: Array, nodal_coords: Array
@@ -96,18 +101,22 @@ class Element(ABC):
         Returns:
             A tuple containing:
                 - Interpolated value at the local coordinates (shape: (n_values,)).
-                - Gradient of the nodal values at the local coordinates (shape: (n_dim, n_values)).
+                - Gradient of the nodal values at the local coordinates (shape: (n_values, n_dim)).
                 - Determinant of the Jacobian (scalar).
         """
         N = self.shape_function(xi)
         dNdr = self.shape_function_derivative(xi)
         J, detJ = self.get_jacobian(xi, nodal_coords)
         dNdX = jnp.linalg.inv(J) @ dNdr
-        return N @ nodal_values, dNdX @ nodal_values, detJ
+        return N @ nodal_values, (dNdX @ nodal_values).T, detJ
 
 
 class Line2(Element):
     """A 2-node linear interval element."""
+
+    def _reference_nodes(self) -> Array:
+        ref_nodes = jnp.array([[-1.0], [1.0]])
+        return ref_nodes
 
     def _default_quadrature(self):
         quad_points = jnp.array([[0.0]])
@@ -145,6 +154,10 @@ class Line2(Element):
 
 class Line3(Element):
     """3-node quadratic line element."""
+
+    def _reference_nodes(self) -> Array:
+        ref_nodes = jnp.array([[-1.0], [1.0], [0.0]])
+        return ref_nodes
 
     def _default_quadrature(self):
         quad_points = jnp.array([[-jnp.sqrt(3.0 / 5.0)], [0.0], [jnp.sqrt(3.0 / 5.0)]])
@@ -194,6 +207,10 @@ class Line3(Element):
 class Tri3(Element):
     """A 3-node linear triangular element."""
 
+    def _reference_nodes(self) -> Array:
+        ref_nodes = jnp.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+        return ref_nodes
+
     def _default_quadrature(self) -> tuple[Array, Array]:
         quad_points = jnp.array([[1.0 / 3, 1.0 / 3]])
         quad_weights = jnp.array([1.0 / 2])
@@ -215,6 +232,12 @@ class Tri6(Element):
     A 6-node quadratic triangular element Node ordering: 3 vertices then 3 edge midpoints.
     0:(0,0), 1:(1,0), 2:(0,1), 3:(0.5,0), 4:(0.5,0.5), 5:(0,0.5)
     """
+
+    def _reference_nodes(self) -> Array:
+        ref_nodes = jnp.array(
+            [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.5, 0.0], [0.5, 0.5], [0.0, 0.5]]
+        )
+        return ref_nodes
 
     def _default_quadrature(self) -> tuple[Array, Array]:
         quad_points = jnp.array(
@@ -272,6 +295,10 @@ class Tri6(Element):
 class Quad4(Element):
     """A 4-node bilinear quadrilateral element."""
 
+    def _reference_nodes(self) -> Array:
+        ref_nodes = jnp.array([[-1.0, -1.0], [1.0, -1.0], [1.0, 1.0], [-1.0, 1.0]])
+        return ref_nodes
+
     def _default_quadrature(self) -> tuple[Array, Array]:
         xi_vals = jnp.array([-1.0 / jnp.sqrt(3), 1.0 / jnp.sqrt(3)])
         w_vals = jnp.array([1.0, 1.0])
@@ -304,6 +331,21 @@ class Quad4(Element):
 
 class Quad8(Element):
     """An 8-node biquadratic quadrilateral element."""
+
+    def _reference_nodes(self) -> Array:
+        ref_nodes = jnp.array(
+            [
+                [-1.0, -1.0],
+                [1.0, -1.0],
+                [1.0, 1.0],
+                [-1.0, 1.0],
+                [0.0, -1.0],
+                [1.0, 0.0],
+                [0.0, 1.0],
+                [-1.0, 0.0],
+            ]
+        )
+        return ref_nodes
 
     def _default_quadrature(self) -> tuple[Array, Array]:
         xi_1d = jnp.array([-jnp.sqrt(3.0 / 5.0), 0.0, jnp.sqrt(3.0 / 5.0)])
@@ -368,6 +410,12 @@ class Quad8(Element):
 class Tetrahedron4(Element):
     """A 4-node linear tetrahedral element."""
 
+    def _reference_nodes(self) -> Array:
+        ref_nodes = jnp.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+        )
+        return ref_nodes
+
     def _default_quadrature(self) -> tuple[Array, Array]:
         quad_points = jnp.array([[1.0 / 4, 1.0 / 4, 1.0 / 4]])
         quad_weights = jnp.array([1.0 / 6])
@@ -388,6 +436,21 @@ class Tetrahedron4(Element):
 
 class Hexahedron8(Element):
     """A 8-node linear hexahedral element."""
+
+    def _reference_nodes(self) -> Array:
+        ref_nodes = jnp.array(
+            [
+                [-1.0, -1.0, -1.0],
+                [1.0, -1.0, -1.0],
+                [1.0, 1.0, -1.0],
+                [-1.0, 1.0, -1.0],
+                [-1.0, -1.0, 1.0],
+                [1.0, -1.0, 1.0],
+                [1.0, 1.0, 1.0],
+                [-1.0, 1.0, 1.0],
+            ]
+        )
+        return ref_nodes
 
     def _default_quadrature(self) -> tuple[Array, Array]:
         a = 1 / jnp.sqrt(3)

--- a/tatva/element/base.py
+++ b/tatva/element/base.py
@@ -55,7 +55,7 @@ class Element(ABC):
 
     @abstractmethod
     def _reference_nodes(self) -> Array:
-        """Returns reference nodes for this element"""
+        """Returns the nodal positions in natural coordinates for this element"""
         raise NotImplementedError
 
     @abstractmethod
@@ -80,13 +80,25 @@ class Element(ABC):
 
     def interpolate(self, xi: Array, nodal_values: Array, nodal_coords: Array) -> Array:
         N = self.shape_function(xi)
-        return N @ nodal_values
+        return jnp.einsum("n,n...->...", N, nodal_values)
 
     def gradient(self, xi: Array, nodal_values: Array, nodal_coords: Array) -> Array:
-        dNdr = self.shape_function_derivative(xi)
-        J, _ = self.get_jacobian(xi, nodal_coords)
-        dNdX = jnp.linalg.inv(J) @ dNdr
-        return (dNdX @ nodal_values).T
+        """Returns the gradient of the nodal values at the local coordinates xi.
+
+        Args:
+            xi: Local coordinates (shape: (n_dim,)).
+            nodal_values: Values at the nodes of the element (shape: (n_nodes, n_values)).
+            nodal_coords: Coordinates of the nodes of the element (shape: (n_nodes, n_dim)).
+
+        Returns:
+            Gradient of the nodal values at the local coordinates (shape: (n_values, n_dim)).
+        """
+        # 'd': spatial dimension, 'n': number of nodes,
+        # '...': any additional dimensions (e.g., values per node)
+        dNdr = self.shape_function_derivative(xi)  # (d, n)
+        J = dNdr @ nodal_coords  # (d, n) x (n, d) -> (d, d)
+        dNdX = jnp.linalg.inv(J) @ dNdr  # (d, d) x (d, n) -> (d, n)
+        return jnp.einsum("dn,n...->...d", dNdX, nodal_values)  # (..., d)
 
     def get_local_values(
         self, xi: Array, nodal_values: Array, nodal_coords: Array
@@ -108,7 +120,11 @@ class Element(ABC):
         dNdr = self.shape_function_derivative(xi)
         J, detJ = self.get_jacobian(xi, nodal_coords)
         dNdX = jnp.linalg.inv(J) @ dNdr
-        return N @ nodal_values, (dNdX @ nodal_values).T, detJ
+        return (
+            jnp.einsum("n,n...->...", N, nodal_values),
+            jnp.einsum("dn,n...->...d", dNdX, nodal_values),
+            detJ,
+        )
 
 
 class Line2(Element):
@@ -141,7 +157,7 @@ class Line2(Element):
         _N, dNdr = self.shape_function(xi), self.shape_function_derivative(xi)
         J, _ = self.get_jacobian(xi, nodal_coords)
         dNdX = dNdr / J
-        return dNdX @ nodal_values
+        return jnp.einsum("n,n...->...", dNdX, nodal_values)
 
     def get_local_values(
         self, xi: Array, nodal_values: Array, nodal_coords: Array
@@ -149,7 +165,11 @@ class Line2(Element):
         N, dNdr = self.shape_function(xi), self.shape_function_derivative(xi)
         J, detJ = self.get_jacobian(xi, nodal_coords)
         dNdX = dNdr / J
-        return N @ nodal_values, dNdX @ nodal_values, detJ
+        return (
+            jnp.einsum("n,n...->...", N, nodal_values),
+            jnp.einsum("n,n...->...", dNdX, nodal_values),
+            detJ,
+        )
 
 
 class Line3(Element):
@@ -191,7 +211,7 @@ class Line3(Element):
         dNdr = self.shape_function_derivative(xi)
         J, _ = self.get_jacobian(xi, nodal_coords)
         dNdS = dNdr / J
-        return dNdS @ nodal_values
+        return jnp.einsum("n,n...->...", dNdS, nodal_values)
 
     def get_local_values(
         self, xi: Array, nodal_values: Array, nodal_coords: Array
@@ -201,7 +221,11 @@ class Line3(Element):
         dNdr = self.shape_function_derivative(xi)
         J, detJ = self.get_jacobian(xi, nodal_coords)
         dNdS = dNdr / J
-        return N @ nodal_values, dNdS @ nodal_values, detJ
+        return (
+            jnp.einsum("n,n...->...", N, nodal_values),
+            jnp.einsum("n,n...->...", dNdS, nodal_values),
+            detJ,
+        )
 
 
 class Tri3(Element):

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -1,11 +1,11 @@
 import jax
 
-jax.config.update("jax_enable_x64", True)  # use double-precision
+jax.config.update("jax_enable_x64", True)
 
 import jax.numpy as jnp
 import numpy as np
 import pytest
-from jax import Array
+
 from tatva.element import (
     Hexahedron8,
     Line2,
@@ -17,71 +17,94 @@ from tatva.element import (
     Tri6,
 )
 
+# ---------------------------------------------------------------------------
+# Physical coordinates used in tests.
+#
+# For Line2/Line3: get_jacobian hardcodes a 2-component tangent vector, so
+# physical coords must be 2D. We embed the line along the x-axis.
+#
+# For all other elements: use _reference_nodes() as physical coords. This
+# gives J = I for affine elements (Tri3, Tet4, Hex8) and a well-conditioned
+# Jacobian for higher-order ones (Tri6, Quad8). Any linear field is
+# represented exactly by all standard Lagrangian elements.
+# ---------------------------------------------------------------------------
+
+LINE2_COORDS = jnp.array([[0.0, 0.0], [1.0, 0.0]])          # x ∈ [0, 1]
+LINE3_COORDS = jnp.array([[0.0, 0.0], [1.0, 0.0], [0.5, 0.0]])  # ends then midpoint
+
+
+def _ref_coords(element_class):
+    return element_class()._reference_nodes()
+
+
+# ---------------------------------------------------------------------------
+# Scalar gradient: u = a · x  =>  ∇u = a  at every quadrature point
+# ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize(
-    "element_class, dim",
+    "element_class, coords, coeffs",
     [
-        (Line2, 1),
-        (Line3, 1),
-        (Tri3, 2),
-        (Tri6, 2),
-        (Quad4, 2),
-        (Quad8, 2),
-        (Tetrahedron4, 3),
-        (Hexahedron8, 3),
+        # 1-D elements embedded in 2D — arc-length derivative of u = 3x equals 3
+        (Line2, LINE2_COORDS,            [3.0]),
+        (Line3, LINE3_COORDS,            [3.0]),
+        # 2-D elements — gradient of u = 2x + 3y equals [2, 3]
+        (Tri3,  _ref_coords(Tri3),       [2.0, 3.0]),
+        (Tri6,  _ref_coords(Tri6),       [2.0, 3.0]),
+        (Quad4, _ref_coords(Quad4),      [2.0, 3.0]),
+        (Quad8, _ref_coords(Quad8),      [2.0, 3.0]),
+        # 3-D elements — gradient of u = 2x + 3y + 4z equals [2, 3, 4]
+        (Tetrahedron4, _ref_coords(Tetrahedron4), [2.0, 3.0, 4.0]),
+        (Hexahedron8,  _ref_coords(Hexahedron8),  [2.0, 3.0, 4.0]),
     ],
 )
-def test_element_patch_test(element_class, dim):
-    """
-    Verifies that the element can represent a constant strain field exactly.
-    """
+def test_scalar_gradient_is_exact(element_class, coords, coeffs):
+    """element.gradient on a linear scalar field must return the exact coefficient vector."""
     element = element_class()
-    key = jax.random.PRNGKey(42)
+    a = jnp.array(coeffs)
 
-    if dim == 1:
-        if element_class is Line2:
-            dummy_xi = (
-                element.quad_points
-            )  # because Line2 has only one quadrature point, we can use it directly
-        else:
-            dummy_xi = element.quad_points[0]
+    # For line elements: u = 3 * x-coordinate (arc-length along x-axis)
+    # For 2-D/3-D elements: u = a · x
+    if element_class in (Line2, Line3):
+        u = 3.0 * coords[:, 0]      # shape (n_nodes,)
+        expected = np.array([3.0])   # arc-length derivative
     else:
-        dummy_xi = element.quad_points[
-            0
-        ]  # Use the first quadrature point to determine number of nodes
-    n_nodes = len(element.shape_function(dummy_xi))
-
-    nodal_coords = jax.random.uniform(key, (n_nodes, dim), minval=0.5, maxval=1.5)
-
-    A = jax.random.normal(key, (dim, dim))
-    if dim == 1:
-        A = A[0]  # For 1D, we only need a single value to represent the gradient
-
-    nodal_values = nodal_coords @ A.T
+        u = coords @ a               # shape (n_nodes,)
+        expected = np.array(coeffs)  # ∇u = a
 
     for xi in element.quad_points:
-        dNdr = element.shape_function_derivative(xi)
-
-        J = dNdr @ nodal_coords
-
-        detJ = jnp.linalg.det(J) if dim > 1 else J[0]
-        assert jnp.abs(detJ) > 1e-10, (
-            f"Element {element_class.__name__} has a singular Jacobian."
+        grad = element.gradient(xi, u, coords)
+        np.testing.assert_allclose(
+            grad, expected, atol=1e-12,
+            err_msg=f"Scalar gradient failed for {element_class.__name__}",
         )
 
-        if dim == 1:
-            invJ = 1.0 / J
-            dNdX = invJ * dNdr
-        else:
-            invJ = jnp.linalg.inv(J)
-            dNdX = invJ @ dNdr
 
-        computed_grad = dNdX @ nodal_values
+# ---------------------------------------------------------------------------
+# Vector gradient: u_i = A[i,j] * x_j  =>  ∂u_i/∂x_j = A[i,j]
+# (component-first convention; line elements excluded — their gradient is
+#  a 1-D arc-length derivative, not a full spatial Jacobian)
+# ---------------------------------------------------------------------------
 
+@pytest.mark.parametrize(
+    "element_class",
+    [Tri3, Tri6, Quad4, Quad8, Tetrahedron4, Hexahedron8],
+)
+def test_vector_gradient_is_exact(element_class):
+    """element.gradient on a linear vector field must return A with layout
+    result[i,j] = ∂u_i/∂x_j (component-first)."""
+    element = element_class()
+    key = jax.random.PRNGKey(0)
+    coords = element._reference_nodes()   # shape (n_nodes, dim)
+    dim = coords.shape[1]
+
+    A = jax.random.normal(key, (dim, dim))
+    # u[k, i] = Σ_j A[i,j] * coords[k,j]  =>  ∂u_i/∂x_j = A[i,j]
+    u = jnp.einsum("ij,kj->ki", A, coords)  # shape (n_nodes, dim)
+
+    for xi in element.quad_points:
+        grad = element.gradient(xi, u, coords)
+        # grad[i,j] = ∂u_i/∂x_j = A[i,j]
         np.testing.assert_allclose(
-            computed_grad,
-            A.T,
-            atol=1e-12,
-            rtol=1e-12,
-            err_msg=f"Failed patch test for {element_class.__name__}",
+            grad, np.array(A), atol=1e-12,
+            err_msg=f"Vector gradient failed for {element_class.__name__}",
         )

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -29,7 +29,7 @@ from tatva.element import (
 # represented exactly by all standard Lagrangian elements.
 # ---------------------------------------------------------------------------
 
-LINE2_COORDS = jnp.array([[0.0, 0.0], [1.0, 0.0]])          # x ∈ [0, 1]
+LINE2_COORDS = jnp.array([[0.0, 0.0], [1.0, 0.0]])  # x ∈ [0, 1]
 LINE3_COORDS = jnp.array([[0.0, 0.0], [1.0, 0.0], [0.5, 0.0]])  # ends then midpoint
 
 
@@ -41,20 +41,21 @@ def _ref_coords(element_class):
 # Scalar gradient: u = a · x  =>  ∇u = a  at every quadrature point
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.parametrize(
     "element_class, coords, coeffs",
     [
         # 1-D elements embedded in 2D — arc-length derivative of u = 3x equals 3
-        (Line2, LINE2_COORDS,            [3.0]),
-        (Line3, LINE3_COORDS,            [3.0]),
+        (Line2, LINE2_COORDS, [3.0]),
+        (Line3, LINE3_COORDS, [3.0]),
         # 2-D elements — gradient of u = 2x + 3y equals [2, 3]
-        (Tri3,  _ref_coords(Tri3),       [2.0, 3.0]),
-        (Tri6,  _ref_coords(Tri6),       [2.0, 3.0]),
-        (Quad4, _ref_coords(Quad4),      [2.0, 3.0]),
-        (Quad8, _ref_coords(Quad8),      [2.0, 3.0]),
+        (Tri3, _ref_coords(Tri3), [2.0, 3.0]),
+        (Tri6, _ref_coords(Tri6), [2.0, 3.0]),
+        (Quad4, _ref_coords(Quad4), [2.0, 3.0]),
+        (Quad8, _ref_coords(Quad8), [2.0, 3.0]),
         # 3-D elements — gradient of u = 2x + 3y + 4z equals [2, 3, 4]
         (Tetrahedron4, _ref_coords(Tetrahedron4), [2.0, 3.0, 4.0]),
-        (Hexahedron8,  _ref_coords(Hexahedron8),  [2.0, 3.0, 4.0]),
+        (Hexahedron8, _ref_coords(Hexahedron8), [2.0, 3.0, 4.0]),
     ],
 )
 def test_scalar_gradient_is_exact(element_class, coords, coeffs):
@@ -65,16 +66,18 @@ def test_scalar_gradient_is_exact(element_class, coords, coeffs):
     # For line elements: u = 3 * x-coordinate (arc-length along x-axis)
     # For 2-D/3-D elements: u = a · x
     if element_class in (Line2, Line3):
-        u = 3.0 * coords[:, 0]      # shape (n_nodes,)
-        expected = np.array([3.0])   # arc-length derivative
+        u = 3.0 * coords[:, 0]  # shape (n_nodes,)
+        expected = np.array([3.0])  # arc-length derivative
     else:
-        u = coords @ a               # shape (n_nodes,)
+        u = coords @ a  # shape (n_nodes,)
         expected = np.array(coeffs)  # ∇u = a
 
     for xi in element.quad_points:
         grad = element.gradient(xi, u, coords)
         np.testing.assert_allclose(
-            grad, expected, atol=1e-12,
+            grad,
+            expected,
+            atol=1e-12,
             err_msg=f"Scalar gradient failed for {element_class.__name__}",
         )
 
@@ -85,6 +88,7 @@ def test_scalar_gradient_is_exact(element_class, coords, coeffs):
 #  a 1-D arc-length derivative, not a full spatial Jacobian)
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.parametrize(
     "element_class",
     [Tri3, Tri6, Quad4, Quad8, Tetrahedron4, Hexahedron8],
@@ -94,7 +98,7 @@ def test_vector_gradient_is_exact(element_class):
     result[i,j] = ∂u_i/∂x_j (component-first)."""
     element = element_class()
     key = jax.random.PRNGKey(0)
-    coords = element._reference_nodes()   # shape (n_nodes, dim)
+    coords = element._reference_nodes()  # shape (n_nodes, dim)
     dim = coords.shape[1]
 
     A = jax.random.normal(key, (dim, dim))
@@ -105,6 +109,41 @@ def test_vector_gradient_is_exact(element_class):
         grad = element.gradient(xi, u, coords)
         # grad[i,j] = ∂u_i/∂x_j = A[i,j]
         np.testing.assert_allclose(
-            grad, np.array(A), atol=1e-12,
+            grad,
+            np.array(A),
+            atol=1e-12,
             err_msg=f"Vector gradient failed for {element_class.__name__}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tensor gradient: T_{ij} = B[i,j,k] * x_k  =>  ∂T_{ij}/∂x_k = B[i,j,k]
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "element_class",
+    [Tri3, Tri6, Quad4, Quad8, Tetrahedron4, Hexahedron8],
+)
+def test_tensor_gradient_is_exact(element_class):
+    """element.gradient on a linear tensor field must return B with layout
+    result[i,j,k] = ∂T_ij/∂x_k (value dims first, spatial dim last)."""
+    element = element_class()
+    key = jax.random.PRNGKey(42)
+    coords = element._reference_nodes()
+    dim_spatial = coords.shape[1]
+    dim_val1, dim_val2 = 2, 2  # arbitrary tensor dimensions
+
+    B = jax.random.normal(key, (dim_val1, dim_val2, dim_spatial))
+    # T[n, i, j] = Σ_k B[i,j,k] * coords[n,k]
+    T = jnp.einsum("ijk,nk->nij", B, coords)  # shape (n_nodes, 2, 2)
+
+    for xi in element.quad_points:
+        grad = element.gradient(xi, T, coords)
+        # grad[i,j,k] = ∂T_ij/∂x_k = B[i,j,k]
+        np.testing.assert_allclose(
+            grad,
+            np.array(B),
+            atol=1e-12,
+            err_msg=f"Tensor gradient failed for {element_class.__name__}",
         )


### PR DESCRIPTION
Earlier, we computed the gradients as du_j/dx_i (spatial/component) as entries, which is conventionally written as du_i/dx_j (component/spatial) [Reference](https://www.continuummechanics.org/deformationgradient.html), and would have led to an error for asymmetric gradients.