### PR TITLE
feat: create sparsity pattern from compound

### DIFF
--- a/tatva/compound/__init__.py
+++ b/tatva/compound/__init__.py
@@ -251,22 +251,16 @@ class Compound:
     @overload
     @classmethod
     def get_sparsity(
-        cls,
-        couple_fields: tuple[Field, ...] = (),
-        block_wise: Literal[False] = False,
+        cls, couple_fields: tuple[Field, ...] = (), block_wise: Literal[False] = False
     ) -> csr_matrix: ...
     @overload
     @classmethod
     def get_sparsity(
-        cls,
-        couple_fields: tuple[Field, ...] = (),
-        block_wise: Literal[True] = True,
+        cls, couple_fields: tuple[Field, ...] = (), block_wise: Literal[True] = True
     ) -> list[list[csr_matrix]]: ...
     @classmethod
     def get_sparsity(
-        cls,
-        couple_fields: tuple[Field, ...] = (),
-        block_wise: bool = False,
+        cls, couple_fields: tuple[Field, ...] = (), block_wise: bool = False
     ) -> csr_matrix | list[list[csr_matrix]]:
         """Create a sparsity pattern automatically from this Compound class and its
         attached mesh.
@@ -289,10 +283,7 @@ class Compound:
             )
 
         return create_sparsity_pattern_from_compound(
-            cls,
-            cls._mesh,
-            couple_fields,
-            block_wise=block_wise,
+            cls, cls._mesh, couple_fields, block_wise=block_wise
         )
 
     def __init__(self, arr: Array | None = None, **kwargs) -> None:

--- a/tatva/compound/__init__.py
+++ b/tatva/compound/__init__.py
@@ -26,9 +26,11 @@ from typing import (
     ClassVar,
     Generator,
     Generic,
+    Literal,
     Self,
     Sequence,
     TypeVar,
+    overload,
 )
 
 import jax.numpy as jnp
@@ -48,6 +50,7 @@ from tatva.compound.mpi import GlobalView
 
 if TYPE_CHECKING:
     from mpi4py import MPI
+    from scipy.sparse import csr_matrix
 
     from tatva.compound.mpi import _FieldGlobalInfo, _LocalLayout
     from tatva.mesh import Mesh, PartitionInfo
@@ -222,6 +225,39 @@ class Compound:
         if cls._layout is None:
             raise CompoundError("Layout not set on Compound class.")
         return cls._layout
+
+    @overload
+    @classmethod
+    def get_sparsity(
+        cls, couple_fields: tuple[Field, ...] = (), block_wise: Literal[False] = False
+    ) -> csr_matrix: ...
+    @overload
+    @classmethod
+    def get_sparsity(
+        cls, couple_fields: tuple[Field, ...] = (), block_wise: Literal[True] = True
+    ) -> list[list[csr_matrix]]: ...
+    @classmethod
+    def get_sparsity(
+        cls, couple_fields: tuple[Field, ...] = (), block_wise: bool = False
+    ) -> csr_matrix | list[list[csr_matrix]]:
+        """Create a sparsity pattern automatically from this Compound class and its
+        attached mesh.
+
+        Stacked nodal fields are fully coupled within elements. Other nodal fields can be
+        coupled if wanted. All other fields (Local, Shared) are only connected to themselves
+        (diagonal entries). For non-trivial couplings, you must create the sparsity
+        pattern manually.
+
+        Args:
+            couple_fields: Tuple of fields to fully couple. Only nodal fields are supported.
+            block_wise: If True, return the pattern as a list of lists of sparse matrices
+                corresponding to the compound fields/blocks. Stacked fields are one block.
+        """
+        from tatva.sparse._extraction import create_sparsity_pattern_from_compound
+
+        return create_sparsity_pattern_from_compound(
+            cls, couple_fields, block_wise=block_wise
+        )
 
     def __init__(self, arr: Array | None = None, **kwargs) -> None:
         """Initialize the state with given keyword arguments."""

--- a/tatva/compound/__init__.py
+++ b/tatva/compound/__init__.py
@@ -149,9 +149,19 @@ class Compound:
 
         for name, spec in new_specs:
             if _is_auto_nodal(spec):
-                # if the first dimension is AUTO, we always set the space to CG
-                # this allows that the default behavior of AUTO fields is to be nodal
-                spec = replace(spec, field_type=FieldType.NODAL)
+                if mesh is None:
+                    raise CompoundError(
+                        f"Mesh must be provided to resolve AUTO size for field '{name}'."
+                    )
+                # if the first dimension is AUTO, we set it to Nodal, and resolve the
+                # shape to be (num_nodes, *rest). this allows that the default behavior of
+                # AUTO fields is to be nodal
+                ft_obj = spec.field_type.get()
+                spec = replace(
+                    spec,
+                    shape=(mesh.coords.shape[0], *spec.shape[1:]),
+                    field_type=ft_obj if isinstance(ft_obj, Nodal) else FieldType.NODAL,
+                )
 
             field_type_obj = spec.field_type.get()
             if (
@@ -166,10 +176,16 @@ class Compound:
         # Create descriptors for all new fields
         name_to_descriptor: dict[str, Field] = {}
 
+        # Optimization: If only one field is planned for stacking, don't stack it.
+        # This avoids the overhead of FieldStackedView (reshaping/slicing on every access).
+        if len(full_nodal_specs) == 1:
+            other_specs = full_nodal_specs + other_specs
+            full_nodal_specs = []
+
         # 1. Process auto-nodal fields first for memory layout (stacked block)
         if full_nodal_specs:
             descriptors, total_size = _create_stacked_descriptors(
-                full_nodal_specs, current_offset, axis=1, mesh=mesh
+                full_nodal_specs, current_offset, axis=1
             )
             name_to_descriptor.update(descriptors)
             current_offset += total_size
@@ -343,91 +359,55 @@ def _is_auto_nodal(spec: _FieldSpec) -> bool:
     return len(spec.shape) > 0 and spec.shape[0] == FieldSize.AUTO
 
 
-def _reshape_shape_rank_1_if_needed(
-    shape: tuple[int, ...],
-) -> tuple[tuple[int, ...], bool]:
-    """Determine if a rank-1 shape should be promoted to rank-2 for stacking."""
-    rank = len(shape)
-    if rank == 0:
-        raise CompoundStackError("Cannot stack scalar fields.")
-    if rank == 1:
-        return (*shape, 1), True
-    return shape, False
-
-
 def _create_stacked_descriptors(
     items: Sequence[tuple[str, _FieldSpec | Field]],
     offset: int,
     axis: int = -1,
-    mesh: Mesh | None = None,
 ) -> tuple[dict[str, FieldStackedView], int]:
     """Unified logic to create stacked descriptors and calculate layout."""
     if not items:
         return {}, 0
 
-    # 1. Resolve true shapes and promote rank if needed
-    resolved_info: list[
-        tuple[str, _FieldSpec | Field, tuple[int, ...], tuple[int, ...], bool]
-    ] = []
+    # 1. Find stacking dimension and prefix
+    first_shape = items[0][1].shape
+    actual_axis = axis % len(first_shape) if len(first_shape) > 0 else 0
+    base_prefix = first_shape[:actual_axis]
+
+    # 2. Validate prefix compatibility and calculate layout
+    stack_layout: list[tuple[str, _FieldSpec | Field, int, int]] = []
+    stack_offset: int = 0
     for name, item in items:
         shape = item.shape
-        if len(shape) > 0 and shape[0] == FieldSize.AUTO:
-            if mesh is None:
-                raise CompoundError(f"Mesh required for AUTO-sized field: {name}")
-            shape = (mesh.coords.shape[0], *shape[1:])
-
-        # We keep the user's requested shape (with AUTO resolved) for the final descriptor,
-        # but use a promoted shape for compatibility checks and layout.
-        actual_shape, promoted = _reshape_shape_rank_1_if_needed(shape)
-        resolved_info.append((name, item, shape, actual_shape, promoted))
-
-    # 2. Validate compatibility
-    first_actual_shape = resolved_info[0][3]
-    rank = len(first_actual_shape)
-    actual_axis = axis % rank
-    base_reduced = (
-        first_actual_shape[:actual_axis] + first_actual_shape[actual_axis + 1 :]
-    )
-
-    for name, _, _, actual_shape, _ in resolved_info:
-        if len(actual_shape) != rank:
+        if len(shape) < actual_axis:
             raise CompoundStackError(
-                f"Field {name} rank {len(actual_shape)} is not compatible with rank {rank}."
+                f"Field {name} rank {len(shape)} is not compatible with stacking axis {actual_axis}."
             )
-        if actual_shape[:actual_axis] + actual_shape[actual_axis + 1 :] != base_reduced:
+        if shape[:actual_axis] != base_prefix:
             raise CompoundStackError(
-                f"Field {name} shape {actual_shape} is not compatible with base shape along axis {actual_axis}."
+                f"Field {name} shape {shape} prefix does not match base shape along axis {actual_axis}."
             )
 
-    # 3. Calculate layout
-    stack_layout: list[
-        tuple[str, _FieldSpec | Field, tuple[int, ...], tuple[int, ...], int, int]
-    ] = []
-    stack_offset: int = 0
-    for name, item, shape, actual_shape, _promoted in resolved_info:
-        extent = actual_shape[actual_axis]
+        suffix = shape[actual_axis:]
+        extent = int(prod(suffix)) if suffix else 1
         start = stack_offset
         end = stack_offset + extent
-        stack_layout.append((name, item, shape, actual_shape, start, end))
+        stack_layout.append((name, item, start, end))
         stack_offset += extent
 
-    stacked_shape = list(first_actual_shape)
-    stacked_shape[actual_axis] = stack_offset
-    stacked_shape_tuple = tuple(stacked_shape)
+    stacked_shape_tuple = base_prefix + (stack_offset,)
     stacked_total_size = int(prod(stacked_shape_tuple))
 
     stacked_field_base = _FieldBase(
         stacked_shape_tuple, _slice=slice(offset, offset + stacked_total_size)
     )
 
-    # 4. Create views
+    # 3. Create views
     descriptors = {}
-    for name, item, shape, _actual_shape, start, end in stack_layout:
-        parent_slice = [slice(None)] * rank
-        parent_slice[actual_axis] = slice(start, end)
+    for name, item, start, end in stack_layout:
+        parent_slice = [slice(None)] * len(base_prefix) + [slice(start, end)]
 
         descriptors[name] = FieldStackedView(
-            shape=shape,  # Pass the RESOLVED user-requested shape here
+            shape=item.shape,
             default_factory=item.default_factory,
             parent_field=stacked_field_base,
             parent_slice=tuple(parent_slice),

--- a/tatva/compound/__init__.py
+++ b/tatva/compound/__init__.py
@@ -34,6 +34,7 @@ from typing import (
 )
 
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jax.tree_util import register_pytree_node_class
 
@@ -148,18 +149,23 @@ class Compound:
         from tatva.compound.field_types import Nodal
 
         for name, spec in new_specs:
+            ft_obj = spec.field_type.get()
+
             if _is_auto_nodal(spec):
-                if mesh is None:
-                    raise CompoundError(
-                        f"Mesh must be provided to resolve AUTO size for field '{name}'."
-                    )
                 # if the first dimension is AUTO, we set it to Nodal, and resolve the
-                # shape to be (num_nodes, *rest). this allows that the default behavior of
-                # AUTO fields is to be nodal
-                ft_obj = spec.field_type.get()
+                # shape to be (num_items, *rest).
+                if isinstance(ft_obj, Nodal) and ft_obj.node_ids is not None:
+                    n_items_field = len(ft_obj.node_ids)
+                else:
+                    if mesh is None:
+                        raise CompoundError(
+                            f"Mesh must be provided to resolve AUTO size for field '{name}'."
+                        )
+                    n_items_field = mesh.coords.shape[0]
+
                 spec = replace(
                     spec,
-                    shape=(mesh.coords.shape[0], *spec.shape[1:]),
+                    shape=(n_items_field, *spec.shape[1:]),
                     field_type=ft_obj if isinstance(ft_obj, Nodal) else FieldType.NODAL,
                 )
 
@@ -245,16 +251,22 @@ class Compound:
     @overload
     @classmethod
     def get_sparsity(
-        cls, couple_fields: tuple[Field, ...] = (), block_wise: Literal[False] = False
+        cls,
+        couple_fields: tuple[Field, ...] = (),
+        block_wise: Literal[False] = False,
     ) -> csr_matrix: ...
     @overload
     @classmethod
     def get_sparsity(
-        cls, couple_fields: tuple[Field, ...] = (), block_wise: Literal[True] = True
+        cls,
+        couple_fields: tuple[Field, ...] = (),
+        block_wise: Literal[True] = True,
     ) -> list[list[csr_matrix]]: ...
     @classmethod
     def get_sparsity(
-        cls, couple_fields: tuple[Field, ...] = (), block_wise: bool = False
+        cls,
+        couple_fields: tuple[Field, ...] = (),
+        block_wise: bool = False,
     ) -> csr_matrix | list[list[csr_matrix]]:
         """Create a sparsity pattern automatically from this Compound class and its
         attached mesh.
@@ -271,8 +283,16 @@ class Compound:
         """
         from tatva.sparse._extraction import create_sparsity_pattern_from_compound
 
+        if cls._mesh is None:
+            raise CompoundError(
+                "Mesh must be set on Compound class to create sparsity pattern."
+            )
+
         return create_sparsity_pattern_from_compound(
-            cls, couple_fields, block_wise=block_wise
+            cls,
+            cls._mesh,
+            couple_fields,
+            block_wise=block_wise,
         )
 
     def __init__(self, arr: Array | None = None, **kwargs) -> None:

--- a/tatva/compound/__init__.py
+++ b/tatva/compound/__init__.py
@@ -34,7 +34,6 @@ from typing import (
 )
 
 import jax.numpy as jnp
-import numpy as np
 from jax import Array
 from jax.tree_util import register_pytree_node_class
 
@@ -250,28 +249,28 @@ class Compound:
 
     @overload
     @classmethod
-    def get_sparsity(
-        cls, couple_fields: tuple[Field, ...] = (), block_wise: Literal[False] = False
-    ) -> csr_matrix: ...
+    def get_sparsity(cls, block_wise: Literal[False] = False) -> csr_matrix: ...
     @overload
     @classmethod
     def get_sparsity(
-        cls, couple_fields: tuple[Field, ...] = (), block_wise: Literal[True] = True
+        cls, block_wise: Literal[True] = True
     ) -> list[list[csr_matrix]]: ...
     @classmethod
     def get_sparsity(
-        cls, couple_fields: tuple[Field, ...] = (), block_wise: bool = False
+        cls, block_wise: bool = False
     ) -> csr_matrix | list[list[csr_matrix]]:
-        """Create a sparsity pattern automatically from this Compound class and its
+        """TODO: Currently, only correct for full nodal fields. Incomplete fields are
+        missing in-element couplings. Other fields are only connected to themselves
+        (diagonal entries)! Do not use blindly for mixed meshes.
+
+        Create a sparsity pattern automatically from this Compound class and its
         attached mesh.
 
-        Stacked nodal fields are fully coupled within elements. Other nodal fields can be
-        coupled if wanted. All other fields (Local, Shared) are only connected to themselves
-        (diagonal entries). For non-trivial couplings, you must create the sparsity
-        pattern manually.
+        Nodal fields are fully coupled within elements. All other fields (Local, Shared)
+        are only connected to themselves (diagonal entries). For non-trivial couplings,
+        you must create the sparsity pattern manually.
 
         Args:
-            couple_fields: Tuple of fields to fully couple. Only nodal fields are supported.
             block_wise: If True, return the pattern as a list of lists of sparse matrices
                 corresponding to the compound fields/blocks. Stacked fields are one block.
         """
@@ -283,7 +282,7 @@ class Compound:
             )
 
         return create_sparsity_pattern_from_compound(
-            cls, cls._mesh, couple_fields, block_wise=block_wise
+            cls, cls._mesh, block_wise=block_wise
         )
 
     def __init__(self, arr: Array | None = None, **kwargs) -> None:

--- a/tatva/compound/field.py
+++ b/tatva/compound/field.py
@@ -79,24 +79,42 @@ def _row_major_strides(shape: tuple[int, ...]) -> tuple[int, ...]:
     return tuple(reversed(strides_rev))
 
 
-def _reshape_affine_metadata(
+def _compute_reshaped_strides(
     shape: tuple[int, ...],
     strides: tuple[int, ...],
     target_shape: tuple[int, ...],
-) -> tuple[tuple[int, ...], tuple[int, ...]]:
+) -> tuple[int, ...]:
     if shape == target_shape:
-        return shape, strides
+        return strides
 
-    compact_shape = tuple(extent for extent in shape if extent != 1)
-    if compact_shape != target_shape:
-        raise ValueError(
-            f"Cannot reshape affine metadata from shape {shape} to {target_shape}."
+    # Find common prefix
+    prefix_len = 0
+    for s1, s2 in zip(shape, target_shape):
+        if s1 == s2:
+            prefix_len += 1
+        else:
+            break
+
+    if (prefix_len < len(shape)) and (len(shape) - prefix_len == 1):
+        # We expect the rest of shape to be exactly 1 dimension (the flattened suffix)
+        extent = shape[prefix_len]
+        suffix = target_shape[prefix_len:]
+        if extent == int(prod(suffix)):
+            extent_stride = strides[prefix_len]
+            suffix_strides = _row_major_strides(suffix)
+            scaled_suffix_strides = tuple(s * extent_stride for s in suffix_strides)
+            return strides[:prefix_len] + scaled_suffix_strides
+
+    # Fallback for dropping 1s
+    compact_shape = tuple(e for e in shape if e != 1)
+    if compact_shape == target_shape:
+        return tuple(
+            stride for extent, stride in zip(shape, strides, strict=True) if extent != 1
         )
 
-    compact_strides = tuple(
-        stride for extent, stride in zip(shape, strides, strict=True) if extent != 1
+    raise ValueError(
+        f"Cannot reshape affine metadata from shape {shape} to {target_shape}."
     )
-    return compact_shape, compact_strides
 
 
 class _FieldBase:
@@ -263,7 +281,7 @@ class FieldStackedView(Field):
                 strides[axis] *= step
                 view_shape[axis] = len(range(start, stop, step))
 
-        _, reshaped_strides = _reshape_affine_metadata(
+        reshaped_strides = _compute_reshaped_strides(
             tuple(view_shape), tuple(strides), self.shape
         )
         self._base_offset = base_offset

--- a/tatva/compound/mpi.py
+++ b/tatva/compound/mpi.py
@@ -31,7 +31,7 @@ from tatva.compound import field_types
 from tatva.compound.field import (
     FieldStackedView,
     _normalize_index,
-    _reshape_affine_metadata,
+    _compute_reshaped_strides,
     _row_major_strides,
 )
 from tatva.mesh import PartitionInfo
@@ -379,7 +379,7 @@ def _layout_from_compound(
                     g_view_shape[axis] = len(range(start, stop, step))
 
             # Reshape affine metadata to match the user's requested field shape
-            _, reshaped_strides = _reshape_affine_metadata(
+            reshaped_strides = _compute_reshaped_strides(
                 tuple(g_view_shape), tuple(g_strides), (n_items_global, *f.shape[1:])
             )
             field_global_info[name] = _FieldGlobalInfo(

--- a/tatva/compound/mpi.py
+++ b/tatva/compound/mpi.py
@@ -137,7 +137,24 @@ class _GlobalFieldIndices:
                     raise IndexError(f"Global node ID {first_idx} not in field subset.")
                 arg = (int(pos),) + arg[1:]
             elif isinstance(first_idx, slice):
-                raise NotImplementedError("Slicing on global subset not supported yet.")
+                # Translate global node ID slice to subset indices
+                start, stop, step = first_idx.start, first_idx.stop, first_idx.step
+                if step is not None and step != 1:
+                    raise NotImplementedError(
+                        "Slicing with step on global subset not supported yet."
+                    )
+
+                idx_start = (
+                    np.searchsorted(self.global_subset, start)
+                    if start is not None
+                    else 0
+                )
+                idx_stop = (
+                    np.searchsorted(self.global_subset, stop)
+                    if stop is not None
+                    else len(self.global_subset)
+                )
+                arg = (slice(idx_start, idx_stop),) + arg[1:]
             else:
                 # Array lookup
                 first_idx_arr = np.asarray(first_idx)

--- a/tatva/compound/mpi.py
+++ b/tatva/compound/mpi.py
@@ -30,8 +30,8 @@ from numpy.typing import NDArray
 from tatva.compound import field_types
 from tatva.compound.field import (
     FieldStackedView,
-    _normalize_index,
     _compute_reshaped_strides,
+    _normalize_index,
     _row_major_strides,
 )
 from tatva.mesh import PartitionInfo
@@ -324,7 +324,10 @@ def _layout_from_compound(
                 # Nodal fields: items correspond to unique global nodes
                 if field_type_obj.node_ids is not None:
                     # Incomplete nodal subset: collective gathering of unique global node IDs
-                    subset_global_nodes = np.asarray(field_type_obj.node_ids)
+                    node_ids_local = np.asarray(field_type_obj.node_ids)
+                    subset_global_nodes = partition_info.nodes_local_to_global[
+                        node_ids_local
+                    ]
                     all_subset = comm.allgather(subset_global_nodes)
                     global_subset = np.unique(np.concatenate(all_subset))
                     n_items_global = len(global_subset)
@@ -353,7 +356,8 @@ def _layout_from_compound(
             isinstance(field_type_obj, field_types.Nodal)
             and field_type_obj.node_ids is not None
         ):
-            subset_global_nodes = np.asarray(field_type_obj.node_ids)
+            node_ids_local = np.asarray(field_type_obj.node_ids)
+            subset_global_nodes = partition_info.nodes_local_to_global[node_ids_local]
             all_subset = comm.allgather(subset_global_nodes)
             g_subset = np.unique(np.concatenate(all_subset))
 
@@ -424,7 +428,10 @@ def _layout_from_compound(
 
             if field_type_obj.node_ids is not None:
                 # Incomplete Nodal: subset mapping
-                subset_global_nodes = np.asarray(field_type_obj.node_ids)
+                node_ids_local = np.asarray(field_type_obj.node_ids)
+                subset_global_nodes = partition_info.nodes_local_to_global[
+                    node_ids_local
+                ]
 
                 # Identify owned nodes within this subset
                 owned_global_nodes = partition_info.nodes_local_to_global[

--- a/tatva/lifter/base.py
+++ b/tatva/lifter/base.py
@@ -278,6 +278,23 @@ class Lifter:
         free = jnp.setdiff1d(all_dofs, constrained, assume_unique=True)
         return free, constrained, free.size
 
+    def adapt_sparsity(self, sparsity: sps.csr_matrix) -> sps.csr_matrix:
+        """Augment and reduce the sparsity pattern to account for all constraints. From
+        the built-in constraints, only Periodic and PeriodicMPI have non-trivial
+        implementations of this method, which add entries to the sparsity pattern to
+        account for the coupling between master and slave dofs.
+        Returns the reduced sparsity pattern for the free DOFs.
+
+        Args:
+            sparsity: Sparsity pattern in SciPy CSR format.
+
+        Returns:
+            Augmented and reduced sparsity pattern in SciPy CSR format.
+        """
+        augmented = self.augment_sparsity(sparsity)
+        reduced = self.reduce_sparsity(augmented)
+        return reduced
+
     def augment_sparsity(self, sparsity: sps.csr_matrix) -> sps.csr_matrix:
         """Augment the sparsity pattern to account for all constraints.
 

--- a/tatva/lifter/constraints.py
+++ b/tatva/lifter/constraints.py
@@ -22,7 +22,6 @@ from functools import wraps
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     Hashable,
     Self,
     TypeVar,
@@ -35,7 +34,6 @@ import numpy as np
 import scipy.sparse as sps
 from jax import Array
 from jax.typing import ArrayLike
-from numpy.typing import NDArray
 
 from tatva.lifter.common import (
     LifterError,
@@ -43,6 +41,7 @@ from tatva.lifter.common import (
     RuntimeValueMap,
     _iter_runtime_values,
 )
+from tatva.utils import create_g2l
 
 if TYPE_CHECKING:
     from mpi4py import MPI
@@ -219,24 +218,6 @@ class Periodic(Constraint):
     def apply_transpose(self, r_full: Array) -> Array:
         """Add residuals from constrained ``dofs`` to ``master_dofs``."""
         return r_full.at[self.master_dofs].add(r_full[self.dofs]).at[self.dofs].set(0.0)
-
-
-def create_g2l(l2g: NDArray) -> Callable[[NDArray], NDArray]:
-    # this method may not be optimal
-    # it works for now
-    sort_idx = np.argsort(l2g)
-    sorted_l2g = l2g[sort_idx]
-
-    def lookup(global_indices: NDArray) -> NDArray:
-        pos = np.searchsorted(sorted_l2g, global_indices)
-        valid = (pos < len(sorted_l2g)) & (
-            sorted_l2g[np.minimum(pos, len(sorted_l2g) - 1)] == global_indices
-        )
-        local_indices = np.full_like(global_indices, -1)
-        local_indices[valid] = sort_idx[pos[valid]]
-        return local_indices
-
-    return lookup
 
 
 class PeriodicMPI(Periodic):

--- a/tatva/operator.py
+++ b/tatva/operator.py
@@ -25,9 +25,9 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Concatenate,
     Generic,
     ParamSpec,
-    Protocol,
     Self,
     TypeAlias,
     TypeVar,
@@ -54,27 +54,24 @@ ElementT = TypeVar("ElementT", bound=Element)
 Numeric: TypeAlias = float | int | jnp.number
 
 
-class MappableOverElementsAndQuads(Protocol[P, RT]):
-    """Internal protocol for functions that are mapped over elements using
-    `Operator.map`."""
-
-    @staticmethod
-    def __call__(
-        xi: jax.Array,
-        *el_values: P.args,
-        **el_kwargs: P.kwargs,
-    ) -> RT: ...
-
+MappableOverElementsAndQuads: TypeAlias = Callable[Concatenate[jax.Array, P], RT]
+"""A Callable that takes a quadrature point (xi) as the first argument, followed by any
+number of additional arguments (P.args and P.kwargs), and returns a jax.Array or a tuple.
+This is the type of function that can be mapped over elements and quadrature points using
+the `Operator.map` method.
+"""
 
 MappableOverElements: TypeAlias = Callable[P, RT]
+"""A Callable that takes any number of arguments (P.args and P.kwargs) and returns a
+jax.Array or a tuple. This is the type of function that can be mapped over elements using
+`Operator.map_over_elements` method.
+"""
 
-
-class MappedCallable(Protocol[P, RT]):
-    @staticmethod
-    def __call__(
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> RT: ...
+MappedCallable: TypeAlias = Callable[P, RT]
+"""A Callable that takes any number of arguments (P.args and P.kwargs) and returns a
+jax.Array or a tuple. This is the type of function returned by the `Operator.map` and
+`Operator.map_over_elements` methods.
+"""
 
 
 @jax.tree_util.register_dataclass

--- a/tatva/sparse/_extraction.py
+++ b/tatva/sparse/_extraction.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -28,6 +29,7 @@ from numpy.typing import NDArray
 from tatva import Mesh
 
 if TYPE_CHECKING:
+    from tatva.compound import Compound, Field
     from tatva.lifter import Lifter
 
 
@@ -286,3 +288,144 @@ def augment_sparsity_with_lifter(
         lifter: Lifter containing constraints.
     """
     return lifter.augment_sparsity(sparsity)
+
+
+def create_sparsity_pattern_from_compound(
+    compound_cls: type[Compound],
+    couple_fields: tuple[Field, ...] = (),
+    block_wise: bool = False,
+) -> sps.csr_matrix | list[list[sps.csr_matrix]]:
+    """Create a sparsity pattern automatically from a Compound class and its attached
+    mesh.
+
+    Stacked nodal fields are fully coupled within elements. Other nodal fields can be
+    coupled if wanted. All other fields (Local, Shared) are only connected to themselves
+    (diagonal entries).
+
+    Args:
+        compound_cls: The Compound class defining the state layout.
+        couple_fields: Tuple of fields to fully couple. Only nodal fields are supported.
+        block_wise: If True, return the pattern as a list of lists of sparse matrices
+            corresponding to the compound fields/blocks. Stacked fields are one block.
+    """
+    from tatva.compound import FieldStackedView
+    from tatva.compound.field_types import Nodal
+
+    mesh = compound_cls._mesh
+    if mesh is None:
+        raise ValueError(
+            "Compound class must have a mesh to create a sparsity pattern."
+        )
+
+    n_nodes = mesh.coords.shape[0]
+    num_elements = mesh.elements.shape[0]
+
+    couple_fields_set = set(couple_fields)
+    main_coupling_list: list[NDArray[np.int32]] = []
+    independent_nodal_list: list[NDArray[np.int32]] = []
+    diagonal_dofs_list: list[NDArray[np.int32]] = []
+
+    for name, f in compound_cls.fields:
+        field_type_obj = f.field_type.get()
+        if isinstance(field_type_obj, Nodal):
+            # Map field DOFs to nodes
+            indices = np.asarray(f.indices(slice(None)))
+            n_items = (
+                len(field_type_obj.node_ids)
+                if field_type_obj.node_ids is not None
+                else n_nodes
+            )
+
+            if n_items > 0:
+                dofs_per_item = indices.size // n_items
+
+                node_dofs = np.full((n_nodes, dofs_per_item), -1, dtype=np.int32)
+                if field_type_obj.node_ids is None:
+                    node_dofs[:] = indices.reshape(n_nodes, dofs_per_item)
+                else:
+                    node_dofs[field_type_obj.node_ids] = indices.reshape(
+                        -1, dofs_per_item
+                    )
+
+                # Map nodes to elements
+                f_element_dofs = node_dofs[mesh.elements].reshape(num_elements, -1)
+
+                is_stacked = isinstance(f, FieldStackedView)
+                is_in_couple = f in couple_fields_set
+
+                if is_stacked or is_in_couple:
+                    main_coupling_list.append(f_element_dofs)
+                else:
+                    independent_nodal_list.append(f_element_dofs)
+        else:
+            warnings.warn(
+                f"Custom space detected for field '{name}'. Only diagonal entries added "
+                "to the sparsity pattern. Please provide your own sparsity pattern if "
+                "cross-coupling is required.",
+                UserWarning,
+            )
+            diagonal_dofs_list.append(np.asarray(f.indices(slice(None))).flatten())
+
+    K_shape = (compound_cls.size, compound_cls.size)
+    all_rows = []
+    all_cols = []
+
+    if main_coupling_list:
+        cg_element_dofs = np.concatenate(main_coupling_list, axis=1)
+        num_elements, num_dofs_per_element = cg_element_dofs.shape
+
+        row_indices = np.repeat(cg_element_dofs, num_dofs_per_element, axis=1).flatten()
+        col_indices = np.tile(cg_element_dofs, (1, num_dofs_per_element)).flatten()
+
+        # Filter out -1 (from incomplete Nodal fields)
+        valid = (row_indices >= 0) & (col_indices >= 0)
+        all_rows.append(row_indices[valid])
+        all_cols.append(col_indices[valid])
+
+    for indep_dofs in independent_nodal_list:
+        num_elements, num_dofs_per_element = indep_dofs.shape
+        row_indices = np.repeat(indep_dofs, num_dofs_per_element, axis=1).flatten()
+        col_indices = np.tile(indep_dofs, (1, num_dofs_per_element)).flatten()
+
+        valid = (row_indices >= 0) & (col_indices >= 0)
+        all_rows.append(row_indices[valid])
+        all_cols.append(col_indices[valid])
+
+    if diagonal_dofs_list:
+        diag_dofs = np.concatenate(diagonal_dofs_list)
+        all_rows.append(diag_dofs)
+        all_cols.append(diag_dofs)
+
+    if not all_rows:
+        full_matrix = sps.csr_matrix(K_shape, dtype=np.int8)
+    else:
+        rows = np.concatenate(all_rows)
+        cols = np.concatenate(all_cols)
+
+        # Fast deduplication using linearized indices
+        num_cols = K_shape[1]
+        linear_indices = rows.astype(np.int64) * num_cols + cols.astype(np.int64)
+        sorted_unique_linear = np.unique(linear_indices)
+
+        sorted_rows = sorted_unique_linear // num_cols
+        sorted_cols = sorted_unique_linear % num_cols
+
+        full_matrix = sps.csr_matrix(
+            (np.ones(sorted_rows.shape[0], dtype=np.int8), (sorted_rows, sorted_cols)),
+            shape=K_shape,
+        )
+
+    if not block_wise:
+        return full_matrix
+
+    # Identify blocks (unique root slices)
+    root_slices = []
+    seen = set()
+    for _, f in compound_cls.fields:
+        s = getattr(f, "_root_slice", getattr(f, "_slice", None))
+        if s is not None and s not in seen:
+            root_slices.append(s)
+            seen.add(s)
+    root_slices.sort(key=lambda s: s.start)
+
+    return [[full_matrix[s1, s2] for s2 in root_slices] for s1 in root_slices]

--- a/tatva/sparse/_extraction.py
+++ b/tatva/sparse/_extraction.py
@@ -27,6 +27,8 @@ from jax.typing import ArrayLike
 from numpy.typing import NDArray
 
 from tatva import Mesh
+from tatva.mesh import PartitionInfo
+from tatva.utils import create_g2l
 
 if TYPE_CHECKING:
     from tatva.compound import Compound, Field
@@ -292,6 +294,7 @@ def augment_sparsity_with_lifter(
 
 def create_sparsity_pattern_from_compound(
     compound_cls: type[Compound],
+    mesh: Mesh,
     couple_fields: tuple[Field, ...] = (),
     block_wise: bool = False,
 ) -> sps.csr_matrix | list[list[sps.csr_matrix]]:
@@ -304,18 +307,13 @@ def create_sparsity_pattern_from_compound(
 
     Args:
         compound_cls: The Compound class defining the state layout.
+        mesh: The Mesh object attached to the Compound.
         couple_fields: Tuple of fields to fully couple. Only nodal fields are supported.
         block_wise: If True, return the pattern as a list of lists of sparse matrices
             corresponding to the compound fields/blocks. Stacked fields are one block.
     """
     from tatva.compound import FieldStackedView
     from tatva.compound.field_types import Nodal
-
-    mesh = compound_cls._mesh
-    if mesh is None:
-        raise ValueError(
-            "Compound class must have a mesh to create a sparsity pattern."
-        )
 
     n_nodes = mesh.coords.shape[0]
     num_elements = mesh.elements.shape[0]
@@ -343,9 +341,11 @@ def create_sparsity_pattern_from_compound(
                 if field_type_obj.node_ids is None:
                     node_dofs[:] = indices.reshape(n_nodes, dofs_per_item)
                 else:
-                    node_dofs[field_type_obj.node_ids] = indices.reshape(
+                    node_ids = np.asarray(field_type_obj.node_ids, dtype=np.int32)
+                    valid_nodes = (node_ids >= 0) & (node_ids < n_nodes)
+                    node_dofs[node_ids[valid_nodes]] = indices.reshape(
                         -1, dofs_per_item
-                    )
+                    )[valid_nodes]
 
                 # Map nodes to elements
                 f_element_dofs = node_dofs[mesh.elements].reshape(num_elements, -1)

--- a/tatva/sparse/_extraction.py
+++ b/tatva/sparse/_extraction.py
@@ -27,11 +27,9 @@ from jax.typing import ArrayLike
 from numpy.typing import NDArray
 
 from tatva import Mesh
-from tatva.mesh import PartitionInfo
-from tatva.utils import create_g2l
 
 if TYPE_CHECKING:
-    from tatva.compound import Compound, Field
+    from tatva.compound import Compound
     from tatva.lifter import Lifter
 
 
@@ -295,32 +293,26 @@ def augment_sparsity_with_lifter(
 def create_sparsity_pattern_from_compound(
     compound_cls: type[Compound],
     mesh: Mesh,
-    couple_fields: tuple[Field, ...] = (),
     block_wise: bool = False,
 ) -> sps.csr_matrix | list[list[sps.csr_matrix]]:
     """Create a sparsity pattern automatically from a Compound class and its attached
     mesh.
 
-    Stacked nodal fields are fully coupled within elements. Other nodal fields can be
-    coupled if wanted. All other fields (Local, Shared) are only connected to themselves
-    (diagonal entries).
+    Nodal fields are fully coupled within elements. All other fields (Local, Shared)
+    are only connected to themselves (diagonal entries).
 
     Args:
         compound_cls: The Compound class defining the state layout.
         mesh: The Mesh object attached to the Compound.
-        couple_fields: Tuple of fields to fully couple. Only nodal fields are supported.
         block_wise: If True, return the pattern as a list of lists of sparse matrices
             corresponding to the compound fields/blocks. Stacked fields are one block.
     """
-    from tatva.compound import FieldStackedView
     from tatva.compound.field_types import Nodal
 
     n_nodes = mesh.coords.shape[0]
     num_elements = mesh.elements.shape[0]
 
-    couple_fields_set = set(couple_fields)
     main_coupling_list: list[NDArray[np.int32]] = []
-    independent_nodal_list: list[NDArray[np.int32]] = []
     diagonal_dofs_list: list[NDArray[np.int32]] = []
 
     for name, f in compound_cls.fields:
@@ -349,14 +341,7 @@ def create_sparsity_pattern_from_compound(
 
                 # Map nodes to elements
                 f_element_dofs = node_dofs[mesh.elements].reshape(num_elements, -1)
-
-                is_stacked = isinstance(f, FieldStackedView)
-                is_in_couple = f in couple_fields_set
-
-                if is_stacked or is_in_couple:
-                    main_coupling_list.append(f_element_dofs)
-                else:
-                    independent_nodal_list.append(f_element_dofs)
+                main_coupling_list.append(f_element_dofs)
         else:
             warnings.warn(
                 f"Custom space detected for field '{name}'. Only diagonal entries added "
@@ -378,15 +363,6 @@ def create_sparsity_pattern_from_compound(
         col_indices = np.tile(cg_element_dofs, (1, num_dofs_per_element)).flatten()
 
         # Filter out -1 (from incomplete Nodal fields)
-        valid = (row_indices >= 0) & (col_indices >= 0)
-        all_rows.append(row_indices[valid])
-        all_cols.append(col_indices[valid])
-
-    for indep_dofs in independent_nodal_list:
-        num_elements, num_dofs_per_element = indep_dofs.shape
-        row_indices = np.repeat(indep_dofs, num_dofs_per_element, axis=1).flatten()
-        col_indices = np.tile(indep_dofs, (1, num_dofs_per_element)).flatten()
-
         valid = (row_indices >= 0) & (col_indices >= 0)
         all_rows.append(row_indices[valid])
         all_cols.append(col_indices[valid])

--- a/tatva/utils.py
+++ b/tatva/utils.py
@@ -22,8 +22,10 @@ from typing import TYPE_CHECKING, Callable, Concatenate, ParamSpec, overload
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jax.typing import ArrayLike
+from numpy.typing import NDArray
 
 if TYPE_CHECKING:
     from tatva.lifter import Lifter
@@ -258,3 +260,21 @@ def _make_projection(
     lhs = jacfwd(_lhs, colored_matrix, color_batch_size=None)
 
     return lhs, _rhs
+
+
+def create_g2l(l2g: NDArray) -> Callable[[NDArray], NDArray]:
+    # this method may not be optimal
+    # it works for now
+    sort_idx = np.argsort(l2g)
+    sorted_l2g = l2g[sort_idx]
+
+    def lookup(global_indices: NDArray) -> NDArray:
+        pos = np.searchsorted(sorted_l2g, global_indices)
+        valid = (pos < len(sorted_l2g)) & (
+            sorted_l2g[np.minimum(pos, len(sorted_l2g) - 1)] == global_indices
+        )
+        local_indices = np.full_like(global_indices, -1)
+        local_indices[valid] = sort_idx[pos[valid]]
+        return local_indices
+
+    return lookup

--- a/tests/test_compound_mpi.py
+++ b/tests/test_compound_mpi.py
@@ -64,6 +64,16 @@ def test_global_indices():
     np.testing.assert_array_equal(MyState._g.l[1], [8])
     np.testing.assert_array_equal(MyState._g.l[3], [9])
 
+    # Check slicing
+    np.testing.assert_array_equal(MyState._g.l[:], [8, 9])
+    np.testing.assert_array_equal(MyState._g.l[1:2], [8])
+    np.testing.assert_array_equal(MyState._g.l[2:4], [9])
+    np.testing.assert_array_equal(MyState._g.l[:2], [8])
+    np.testing.assert_array_equal(MyState._g.l[2:], [9])
+
+    with pytest.raises(NotImplementedError):
+        MyState._g.l[::2]
+
     with pytest.raises(IndexError):
         MyState._g.l[0]
 

--- a/tests/test_compound_mpi.py
+++ b/tests/test_compound_mpi.py
@@ -30,12 +30,15 @@ def test_global_indices():
     if rank == 0:
         l2g = np.array([0, 1, 2], dtype=np.int32)
         n_owned = 2
+        local_l_nodes = jnp.array([1])  # global 1 is local 1
     elif rank == 1:
         l2g = np.array([2, 3, 1], dtype=np.int32)
         n_owned = 2
+        local_l_nodes = jnp.array([2, 1])  # global 1 is local 2, global 3 is local 1
     else:
         l2g = np.array([], dtype=np.int32)
         n_owned = 0
+        local_l_nodes = jnp.array([], dtype=int)
 
     p_info = PartitionInfo(nodes_local_to_global=l2g, n_owned_nodes=n_owned)
     mock_mesh = Mesh(
@@ -45,8 +48,8 @@ def test_global_indices():
     class MyState(Compound, mesh=mock_mesh, partition_info=p_info, comm=comm):
         u = field(shape=(FieldSize.AUTO, 2))
         l = field(
-            shape=(2, 1),
-            field_type=Nodal(node_ids=jnp.array([1, 3])),
+            shape=(FieldSize.AUTO, 1),
+            field_type=Nodal(node_ids=local_l_nodes),
         )
 
     # Full field u (global shape 4x2)

--- a/tests/test_exchange_plan.py
+++ b/tests/test_exchange_plan.py
@@ -182,17 +182,17 @@ def test_exchange_plan_incomplete_nodal():
         p_info = PartitionInfo(
             nodes_local_to_global=np.array([0, 1], dtype=np.int32), n_owned_nodes=1
         )
-        subset = np.array([0], dtype=np.int32)
+        subset_local = np.array([0], dtype=np.int32)
     elif rank == 1:
         p_info = PartitionInfo(
             nodes_local_to_global=np.array([1, 2], dtype=np.int32), n_owned_nodes=2
         )
-        subset = np.array([2], dtype=np.int32)
+        subset_local = np.array([1], dtype=np.int32)  # global 2 is local index 1
     else:
         p_info = PartitionInfo(
             nodes_local_to_global=np.array([], dtype=np.int32), n_owned_nodes=0
         )
-        subset = np.array([], dtype=np.int32)
+        subset_local = np.array([], dtype=np.int32)
 
     mock_mesh = Mesh(
         coords=jnp.zeros((len(p_info.nodes_local_to_global), 1)),
@@ -202,8 +202,8 @@ def test_exchange_plan_incomplete_nodal():
     class MyState(Compound, mesh=mock_mesh, partition_info=p_info, comm=comm):
         u = field(shape=(FieldSize.AUTO, 1), field_type=FieldType.NODAL)
         l = field(
-            shape=(len(subset), 1),
-            field_type=Nodal(node_ids=subset),
+            shape=(FieldSize.AUTO, 1),
+            field_type=Nodal(node_ids=subset_local),
         )
 
     lifter = Lifter(MyState.size)


### PR DESCRIPTION
this PR ships a few minor improvements:
- create sparsity pattern from compound, optionally block-wise
- enable stacking fields of any dimension (if the prefix, i.e. first dimension/n_nodes match)
- incomplete Nodal fields take local node ids now instead of global ids
- add adapt_sparsity which does both augment, and reduce