### PR TITLE
Feat/sparsity pattern

### DIFF
--- a/tatva/compound/__init__.py
+++ b/tatva/compound/__init__.py
@@ -247,44 +247,6 @@ class Compound:
             raise CompoundError("Layout not set on Compound class.")
         return cls._layout
 
-    @overload
-    @classmethod
-    def get_sparsity(cls, block_wise: Literal[False] = False) -> csr_matrix: ...
-    @overload
-    @classmethod
-    def get_sparsity(
-        cls, block_wise: Literal[True] = True
-    ) -> list[list[csr_matrix]]: ...
-    @classmethod
-    def get_sparsity(
-        cls, block_wise: bool = False
-    ) -> csr_matrix | list[list[csr_matrix]]:
-        """TODO: Currently, only correct for full nodal fields. Incomplete fields are
-        missing in-element couplings. Other fields are only connected to themselves
-        (diagonal entries)! Do not use blindly for mixed meshes.
-
-        Create a sparsity pattern automatically from this Compound class and its
-        attached mesh.
-
-        Nodal fields are fully coupled within elements. All other fields (Local, Shared)
-        are only connected to themselves (diagonal entries). For non-trivial couplings,
-        you must create the sparsity pattern manually.
-
-        Args:
-            block_wise: If True, return the pattern as a list of lists of sparse matrices
-                corresponding to the compound fields/blocks. Stacked fields are one block.
-        """
-        from tatva.sparse._extraction import create_sparsity_pattern_from_compound
-
-        if cls._mesh is None:
-            raise CompoundError(
-                "Mesh must be set on Compound class to create sparsity pattern."
-            )
-
-        return create_sparsity_pattern_from_compound(
-            cls, cls._mesh, block_wise=block_wise
-        )
-
     def __init__(self, arr: Array | None = None, **kwargs) -> None:
         """Initialize the state with given keyword arguments."""
         if arr is not None:

--- a/tatva/sparse/__init__.py
+++ b/tatva/sparse/__init__.py
@@ -3,7 +3,11 @@ from ._extraction import (
     pattern_from_mesh,
 )
 from .base import ColoredMatrix, jacfwd, linearized_jacfwd
-from .tracer import pattern_from_energy, pattern_from_virtual_work
+from .tracer import (
+    pattern_from_energy,
+    pattern_from_virtual_work,
+    register_elementwise_ffi,
+)
 
 
 def __getattr__(name):
@@ -31,4 +35,5 @@ __all__ = [
     "pattern_from_virtual_work",
     "pattern_from_compound",
     "pattern_from_mesh",
+    "register_elementwise_ffi",
 ]

--- a/tatva/sparse/__init__.py
+++ b/tatva/sparse/__init__.py
@@ -1,32 +1,34 @@
-from ._coloring import (
-    distance2_colors,
-    largest_degree_first_distance2_colors,
-    smallest_last_distance2_colors,
-)
 from ._extraction import (
-    augment_sparsity_with_lifter,
-    create_sparsity_pattern,
-    create_sparsity_pattern_KKT,
-    create_sparsity_pattern_master_slave,
-    get_bc_indices,
-    reduce_sparsity_pattern,
+    pattern_from_compound,
+    pattern_from_mesh,
 )
 from .base import ColoredMatrix, jacfwd, linearized_jacfwd
-from .tracer import trace_energy_sparsity, trace_virtual_work_sparsity
+from .tracer import pattern_from_energy, pattern_from_virtual_work
+
+
+def __getattr__(name):
+    deprecated_fn = (
+        "create_sparsity_pattern",
+        "reduce_sparsity_pattern",
+        "create_sparsity_pattern_KKT",
+        "create_sparsity_pattern_master_slave",
+        "get_bc_indices",
+    )
+    if name in deprecated_fn:
+        raise ImportError(
+            f"The function {name!r} is deprecated and does not exist anymore. "
+            "Please use the new sparsity functions. "
+            "Check the documentation for more information. "
+        )
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "ColoredMatrix",
-    "augment_sparsity_with_lifter",
-    "create_sparsity_pattern",
-    "create_sparsity_pattern_KKT",
-    "create_sparsity_pattern_master_slave",
-    "distance2_colors",
-    "get_bc_indices",
     "jacfwd",
-    "largest_degree_first_distance2_colors",
     "linearized_jacfwd",
-    "reduce_sparsity_pattern",
-    "smallest_last_distance2_colors",
-    "trace_energy_sparsity",
-    "trace_virtual_work_sparsity",
+    "pattern_from_energy",
+    "pattern_from_virtual_work",
+    "pattern_from_compound",
+    "pattern_from_mesh",
 ]

--- a/tatva/sparse/__init__.py
+++ b/tatva/sparse/__init__.py
@@ -12,6 +12,7 @@ from ._extraction import (
     reduce_sparsity_pattern,
 )
 from .base import ColoredMatrix, jacfwd, linearized_jacfwd
+from .tracer import trace_energy_sparsity, trace_virtual_work_sparsity
 
 __all__ = [
     "ColoredMatrix",
@@ -26,4 +27,6 @@ __all__ = [
     "linearized_jacfwd",
     "reduce_sparsity_pattern",
     "smallest_last_distance2_colors",
+    "trace_energy_sparsity",
+    "trace_virtual_work_sparsity",
 ]

--- a/tatva/sparse/__init__.py
+++ b/tatva/sparse/__init__.py
@@ -31,9 +31,9 @@ __all__ = [
     "ColoredMatrix",
     "jacfwd",
     "linearized_jacfwd",
-    "pattern_from_energy",
-    "pattern_from_virtual_work",
     "pattern_from_compound",
+    "pattern_from_energy",
     "pattern_from_mesh",
+    "pattern_from_virtual_work",
     "register_elementwise_ffi",
 ]

--- a/tatva/sparse/_extraction.py
+++ b/tatva/sparse/_extraction.py
@@ -30,7 +30,7 @@ from tatva import Mesh
 if TYPE_CHECKING:
     from scipy.sparse import csr_matrix
 
-    from tatva.compound import Compound, CompoundError
+    from tatva.compound import Compound
     from tatva.lifter import Lifter
 
 
@@ -137,6 +137,7 @@ def pattern_from_compound(
         block_wise: If True, return the pattern as a list of lists of sparse matrices
             corresponding to the compound fields/blocks. Stacked fields are one block.
     """
+    from tatva.compound import CompoundError
     from tatva.compound.field_types import Nodal
 
     if compound_cls._mesh is None:

--- a/tatva/sparse/_extraction.py
+++ b/tatva/sparse/_extraction.py
@@ -18,18 +18,19 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
 import numpy as np
 import scipy.sparse as sps
-from jax import Array
 from jax.typing import ArrayLike
 from numpy.typing import NDArray
 
 from tatva import Mesh
 
 if TYPE_CHECKING:
-    from tatva.compound import Compound
+    from scipy.sparse import csr_matrix
+
+    from tatva.compound import Compound, CompoundError
     from tatva.lifter import Lifter
 
 
@@ -86,7 +87,7 @@ def _create_sparse_structure(
     )
 
 
-def create_sparsity_pattern(mesh: Mesh, n_dofs_per_node: int) -> sps.csr_matrix:
+def pattern_from_mesh(mesh: Mesh, n_dofs_per_node: int) -> sps.csr_matrix:
     """Create a sparsity pattern using SciPy's COO format for efficient setup on CPU.
 
     Args:
@@ -101,184 +102,7 @@ def create_sparsity_pattern(mesh: Mesh, n_dofs_per_node: int) -> sps.csr_matrix:
     return _create_sparse_structure(elements, n_dofs_per_node, K_shape)
 
 
-def get_bc_indices(
-    sparsity_pattern: sps.csr_matrix, fixed_dofs: Array | NDArray
-) -> tuple[NDArray, NDArray]:
-    """Get the indices of the fixed degrees of freedom.
-
-    Args:
-        sparsity_pattern: scipy.sparse.csr_matrix
-        fixed_dofs: (num_fixed_dofs,)
-
-    Returns:
-        zero_indices: (num_zero_indices,)
-        one_indices: (num_one_indices,)
-    """
-
-    row_indices, col_indices = sparsity_pattern.nonzero()
-    zero_indices = []
-    one_indices = []
-
-    for dof in fixed_dofs:
-        indexes = np.where(row_indices == dof)[0]
-        for idx in indexes:
-            zero_indices.append(int(idx))
-
-        idx = np.where((row_indices == dof) & (col_indices == dof))[0][0]
-        one_indices.append(int(idx))
-
-    return np.array(zero_indices), np.array(one_indices)
-
-
-def create_sparsity_pattern_KKT(
-    mesh: Mesh, n_dofs_per_node: int, B: ArrayLike
-) -> sps.csr_matrix:
-    """Create KKT sparsity pattern in SciPy CSR format.
-
-    Block structure:
-        [ K   B^T ]
-        [ B    C  ]
-    where C is identity (matching your current implementation).
-    """
-    B_np = np.asarray(B)
-    nb_cons = B_np.shape[0]
-
-    # K pattern (convert to CSR)
-    K = create_sparsity_pattern(mesh, n_dofs_per_node)
-
-    # B pattern from dense B (keep only structure)
-    B_pattern = sps.csr_matrix((B_np != 0).astype(np.int8))
-    BT_pattern = B_pattern.T
-
-    # TODO: decide if we want the true saddle-point structure with zero C block, or if we
-    # want to keep the identity
-    C = sps.eye(nb_cons, format="csr", dtype=np.int8)
-
-    KKT = sps.block_array(
-        [[K, BT_pattern], [B_pattern, C]],
-        format="csr",
-    )
-    return KKT
-
-
-def reduce_sparsity_pattern(
-    pattern: sps.csr_matrix, free_dofs: ArrayLike
-) -> sps.csr_matrix:
-    """Reduce a sparse matrix pattern in CSR format to only the free dofs.
-
-    Args:
-        pattern (sps.csr_matrix): Sparse matrix pattern in CSR format on the full
-            set of dofs.
-        free_dofs: Array of free dofs as integer indices.
-    """
-    free_dofs = np.asarray(free_dofs, dtype=np.int64)
-    return pattern[free_dofs][:, free_dofs]
-
-
-def create_sparsity_pattern_master_slave(
-    mesh: Mesh,
-    n_dofs_per_node: int,
-    master_slave_map: ArrayLike,
-) -> sps.csr_matrix:
-    """Create a sparsity pattern for a system with master–slave DOF mapping, e.g.,
-    periodic BCs.
-
-    The returned sparsity corresponds to the reduced system defined on master DOFs only.
-
-    Args:
-        mesh: Mesh object.
-        n_dofs_per_node: Number of degrees of freedom per node.
-        master_slave_map: Array of shape (n_full_dofs,) where each entry maps a full DOF
-            index to its master DOF index (masters map to themselves). Optionally, an
-            array of shape (n_nodes,) mapping nodes to master nodes; this will be expanded
-            to DOF-level by preserving the per-node DOF offset. Entries can be set -1 to
-            indicate Dirichlet BCs (removal from system).
-
-    Returns:
-        jax.experimental.sparse.BCOO: Sparsity pattern of the reduced (master-only)
-        system.
-    """
-
-    n_nodes = int(mesh.coords.shape[0])
-    n_full = int(n_nodes * n_dofs_per_node)
-
-    arr = np.asarray(master_slave_map, dtype=np.int64)
-
-    if arr.ndim != 1:
-        raise ValueError("master_slave_map array must be 1D.")
-    if arr.size == n_nodes:
-        # Node-level mapping: expand to DOF-level preserving component offsets
-        map_arr = np.full(n_full, -1, dtype=np.int64)
-        for node in range(n_nodes):
-            base_s = node * n_dofs_per_node
-            master_node = int(arr[node])
-            if master_node < 0:
-                continue
-            base_m = master_node * n_dofs_per_node
-            for k in range(n_dofs_per_node):
-                map_arr[base_s + k] = base_m + k
-    elif arr.size == n_full:
-        map_arr = arr
-    else:
-        raise ValueError(
-            "master_slave_map array must have length n_nodes or n_full_dofs."
-        )
-
-    # Normalize to final masters in case of chaining
-    # (map may already be idempotent; this is safe either way)
-    while True:
-        valid = map_arr >= 0
-        if not np.any(valid):
-            break
-        new_map = map_arr.copy()
-        new_map[valid] = map_arr[map_arr[valid]]
-        new_map[~valid] = -1
-        if np.array_equal(new_map, map_arr):
-            break
-        map_arr = new_map
-
-    # Create full-system sparsity from connectivity, then project via mapping
-    full_pattern_csr = _create_sparse_structure(
-        mesh.elements, n_dofs_per_node, K_shape=(n_full, n_full)
-    )
-    full_pattern = full_pattern_csr.tocoo()  # COO for easy access to indices
-
-    I_full = full_pattern.row.astype(np.int64)
-    J_full = full_pattern.col.astype(np.int64)
-
-    # Unique masters and compaction to 0..n_red-1
-    masters = np.unique(map_arr)
-    # Handle -1 in dofmap (dirichlet BCs)
-    masters_reduced = masters[masters >= 0]
-    n_red = int(masters_reduced.size)
-    # Map master DOF id in [0, n_full) -> compact id in [0, n_red)
-    master_to_compact = -np.ones(n_full, dtype=np.int64)
-    master_to_compact[masters_reduced] = np.arange(n_red, dtype=np.int64)
-
-    mapped_I = map_arr[I_full]
-    mapped_J = map_arr[J_full]
-    valid_entries = (mapped_I >= 0) & (mapped_J >= 0)
-
-    mapped_I = mapped_I[valid_entries]
-    mapped_J = mapped_J[valid_entries]
-
-    I_red = master_to_compact[mapped_I]
-    J_red = master_to_compact[mapped_J]
-
-    # Deduplicate pairs and set data to 1 (pattern only)
-    keys = I_red * n_red + J_red
-    uniq, _ = np.unique(keys, return_inverse=False), None
-    Iu = (uniq // n_red).astype(np.int32)
-    Ju = (uniq % n_red).astype(np.int32)
-    data = np.ones(Iu.shape[0], dtype=np.int32)
-
-    return sps.csr_matrix(
-        (data, (Iu, Ju)),
-        shape=(n_red, n_red),
-    )
-
-
-def augment_sparsity_with_lifter(
+def _adapt_sparsity_with_lifter(
     sparsity: sps.csr_matrix, lifter: Lifter
 ) -> sps.csr_matrix:
     """Augment the sparsity pattern with constraints from a lifter.
@@ -287,12 +111,19 @@ def augment_sparsity_with_lifter(
         sparsity: Sparsity pattern in SciPy CSR format.
         lifter: Lifter containing constraints.
     """
-    return lifter.augment_sparsity(sparsity)
+    return lifter.adapt_sparsity(sparsity)
 
 
-def create_sparsity_pattern_from_compound(
+@overload
+def pattern_from_compound(
+    compound_cls: type[Compound], block_wise: Literal[False] = False
+) -> csr_matrix: ...
+@overload
+def pattern_from_compound(
+    compound_cls: type[Compound], block_wise: Literal[True] = True
+) -> list[list[csr_matrix]]: ...
+def pattern_from_compound(
     compound_cls: type[Compound],
-    mesh: Mesh,
     block_wise: bool = False,
 ) -> sps.csr_matrix | list[list[sps.csr_matrix]]:
     """Create a sparsity pattern automatically from a Compound class and its attached
@@ -303,14 +134,18 @@ def create_sparsity_pattern_from_compound(
 
     Args:
         compound_cls: The Compound class defining the state layout.
-        mesh: The Mesh object attached to the Compound.
         block_wise: If True, return the pattern as a list of lists of sparse matrices
             corresponding to the compound fields/blocks. Stacked fields are one block.
     """
     from tatva.compound.field_types import Nodal
 
-    n_nodes = mesh.coords.shape[0]
-    num_elements = mesh.elements.shape[0]
+    if compound_cls._mesh is None:
+        raise CompoundError(
+            "Mesh must be set on Compound class to create sparsity pattern."
+        )
+
+    n_nodes = compound_cls._mesh.coords.shape[0]
+    num_elements = compound_cls._mesh.elements.shape[0]
 
     main_coupling_list: list[NDArray[np.int32]] = []
     diagonal_dofs_list: list[NDArray[np.int32]] = []
@@ -340,7 +175,9 @@ def create_sparsity_pattern_from_compound(
                     )[valid_nodes]
 
                 # Map nodes to elements
-                f_element_dofs = node_dofs[mesh.elements].reshape(num_elements, -1)
+                f_element_dofs = node_dofs[compound_cls._mesh.elements].reshape(
+                    num_elements, -1
+                )
                 main_coupling_list.append(f_element_dofs)
         else:
             warnings.warn(

--- a/tatva/sparse/tracer.py
+++ b/tatva/sparse/tracer.py
@@ -1,0 +1,1764 @@
+"""
+Determine the Hessian sparsity pattern of a scalar JAX function E(u)
+by propagating ancestor-DOF sets through the *forward* computational graph.
+This is implemented as a custom JAX tracer that tracks the dependency of each
+intermediate variable on the input DOFs, and records pairs of DOFs that interact nonlinearly in the graph.
+
+"""
+
+import inspect
+from typing import (
+    Any,
+    Callable,
+    Concatenate,
+    Dict,
+    List,
+    ParamSpec,
+    Sequence,
+    Set,
+    Tuple,
+)
+
+import jax
+import numpy as np
+import scipy.sparse as sps
+from jax import Array
+from jax.extend.core import Jaxpr, JaxprEqn, Literal, Var
+
+P = ParamSpec("P")
+
+
+def _get_shape(var: Var | Literal) -> Tuple[int, ...]:
+    """Helper to safely retrieve shape from a JAX Var/Literal abstract value (satisfying static type checkers)."""
+    return getattr(var.aval, "shape", ())
+
+
+def _unwrap_jit(fn):
+    """Recursively unwrap `@jax.jit` / `@pjit` decorators only.
+
+    `jax.grad`, `jax.vmap`, and `functools.wraps`-based wrappers also set `__wrapped__`,
+    so blindly removing `__wrapped__` would strip semantic transforms (e.g., turning
+    `jax.grad(E)` back into `E`). We only unwrap `PjitFunction`-class wrappers, which
+    @jax.jit` produces — this preserves any `grad`/`vmap` layers underneath.
+    """
+    while type(fn).__name__ in ("PjitFunction", "JitWrapped") and hasattr(
+        fn, "__wrapped__"
+    ):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _broadcast_single_row(row: sps.csr_matrix, N: int) -> sps.csr_matrix:
+    """Replicate a single-row CSR matrix N times, ~250x faster than sps.vstack([row]*N).
+
+    Builds the result directly via a uniform indptr (each row has the same nnz),
+    bypassing the O(N) Python overhead of sps.vstack.
+    """
+    if N <= 0:
+        return sps.csr_matrix((0, row.shape[1]), dtype=row.dtype)
+    m = row.nnz
+    if m == 0:
+        return sps.csr_matrix((N, row.shape[1]), dtype=row.dtype)
+    indptr = np.arange(N + 1, dtype=row.indptr.dtype) * m
+    indices = np.tile(row.indices, N)
+    data = np.tile(row.data, N)
+    return sps.csr_matrix((data, indices, indptr), shape=(N, row.shape[1]))
+
+
+class CouplingAccumulator:
+    """Accumulates Hessian coupling pairs as numpy-array chunks; fingerprints dep matrices to skip redundant recordings."""
+
+    def __init__(self, n_dofs: int):
+        self.n_dofs = n_dofs
+        self._row_chunks: List[np.ndarray] = []
+        self._col_chunks: List[np.ndarray] = []
+        self._seen_fingerprints: Set[int] = set()
+
+    def add_coords(self, rows: np.ndarray, cols: np.ndarray) -> None:
+        """Append a chunk of coordinate pairs without converting to Python lists."""
+        if rows.size == 0:
+            return
+        self._row_chunks.append(np.asarray(rows))
+        self._col_chunks.append(np.asarray(cols))
+
+    def record_dep(
+        self, dep: sps.csr_matrix, trial_test_split: int | None = None
+    ) -> None:
+        """Compute dep.T @ dep couplings; skip if an identical dep structure has already been recorded."""
+        if dep.nnz == 0:
+            return
+        # Fingerprint: identical (indptr, indices) + split → identical couplings
+        fp = hash(
+            (
+                dep.indptr.tobytes(),
+                dep.indices.tobytes(),
+                trial_test_split,
+                dep.shape[1],
+            )
+        )
+        if fp in self._seen_fingerprints:
+            return
+        self._seen_fingerprints.add(fp)
+        P = (dep.T @ dep).tocsr()
+        r, c = P.nonzero()
+        if trial_test_split is not None:
+            mask = ((r < trial_test_split) & (c >= trial_test_split)) | (
+                (r >= trial_test_split) & (c < trial_test_split)
+            )
+            r = r[mask]
+            c = c[mask]
+        self.add_coords(r, c)
+
+    def finalize(self) -> sps.csr_matrix:
+        """Build the final binary CSR sparsity pattern from the accumulated chunks."""
+        if not self._row_chunks:
+            return sps.csr_matrix((self.n_dofs, self.n_dofs), dtype=np.int8)
+        rows = np.concatenate(self._row_chunks)
+        cols = np.concatenate(self._col_chunks)
+        data = np.ones(rows.shape[0], dtype=np.int8)
+        pat = sps.csr_matrix((data, (rows, cols)), shape=(self.n_dofs, self.n_dofs))
+        pat.sum_duplicates()
+        pat.data[:] = 1
+        return pat
+
+
+# ---------------------------------------------------------------------------
+# primitive classification
+# ---------------------------------------------------------------------------
+
+_NONLINEAR_UNARY = frozenset(
+    {
+        "sin",
+        "cos",
+        "tan",
+        "asin",
+        "acos",
+        "atan",
+        "exp",
+        "exp2",
+        "expm1",
+        "log",
+        "log1p",
+        "log2",
+        "sqrt",
+        "rsqrt",
+        "cbrt",
+        "tanh",
+        "sinh",
+        "cosh",
+        "atanh",
+        "asinh",
+        "acosh",
+        "erf",
+        "erfc",
+        "erfinv",
+        "lgamma",
+        "digamma",
+        "logistic",
+    }
+)
+
+_NONLINEAR_BINARY = frozenset(
+    {
+        "mul",
+        "div",
+        "rem",
+        "pow",
+        "atan2",
+        "igamma",
+        "igammac",
+        "nextafter",
+        "complex",
+    }
+)
+
+
+class TracerRegistry:
+    """Registry for JAX primitive dependency propagation handlers."""
+
+    def __init__(self):
+        self._handlers = {}
+
+    def register(self, *primitive_names: str):
+        """Decorator to register a handler for one or more JAX primitives."""
+
+        def decorator(func):
+            for name in primitive_names:
+                self._handlers[name] = func
+            return func
+
+        return decorator
+
+    def get(self, primitive_name: str, default):
+        """Get the registered handler, or return the default."""
+        return self._handlers.get(primitive_name, default)
+
+
+# Global registry instance
+TRACER_REGISTRY = TracerRegistry()
+
+
+class SparseDepSet:
+    def __init__(self, dep: sps.csr_matrix, shape: tuple):
+        """
+        Represents the dependency set of an array as a sparse boolean matrix.
+
+        Args:
+            dep: sps.csr_matrix of shape (prod(shape), n_dofs) with boolean data
+            shape: logical shape of the array this dep-set corresponds to (e.g., (3,4) for a 3×4 array);
+                   the dep-array is always flattened in row-major order
+        """
+        self.dep = dep  # sps.csr_matrix of shape (prod(shape), n_dofs)
+        self.shape = tuple(shape)
+
+    def copy(self) -> "SparseDepSet":
+        return SparseDepSet(self.dep.copy(), self.shape)
+
+    def reshape(self, *ns) -> "SparseDepSet":
+        return SparseDepSet(self.dep, ns)
+
+    @classmethod
+    def empty(cls, shape: tuple, n_dofs: int) -> "SparseDepSet":
+        """Create a zero-dependency SparseDepSet of shape (*shape, n_dofs)."""
+        size = int(np.prod(shape))
+        dep = sps.csr_matrix((size, n_dofs), dtype=bool)
+        return cls(dep, shape)
+
+    @classmethod
+    def singletons(cls, n_dofs: int) -> "SparseDepSet":
+        """Create an identity-seeded SparseDepSet of shape (n_dofs,) where element i depends only on DOF i."""
+        dep = sps.eye(n_dofs, format="csr", dtype=bool)
+        return cls(dep, (n_dofs,))
+
+    def total_union(self) -> "SparseDepSet":
+        """OR all dependency sets in this array into a single 1D vector of shape ()."""
+        if self.dep.shape[0] == 0:
+            return SparseDepSet.empty((), self.dep.shape[1])
+        reduced = sps.csr_matrix(self.dep.sum(axis=0).astype(bool))
+        return SparseDepSet(reduced, ())
+
+    def broadcast_to(self, S_out: tuple) -> "SparseDepSet":
+        """Broadcast this dep-array to a new logical shape S_out."""
+        S_in = self.shape
+        if S_in == S_out:
+            return self
+        src_indices = np.arange(int(np.prod(S_in))).reshape(S_in)
+        mapped_indices = np.broadcast_to(src_indices, S_out).ravel()
+        return SparseDepSet(self.dep[mapped_indices], S_out)
+
+    def record_couplings(
+        self,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None = None,
+    ) -> None:
+        """Record all active self- and cross-coupling variable pairs via the global accumulator."""
+        acc.record_dep(self.dep, trial_test_split)
+
+
+class TraceState:
+    """Encapsulates the state of dependency propagation and concrete value routing during tracing."""
+
+    def __init__(
+        self,
+        n_dofs: int,
+        active_ids: Set[int],
+        tags: dict | None = None,
+        sub_info: dict | None = None,
+    ):
+        """
+        Args:
+            n_dofs: total number of DOFs (size of the input variable)
+            active_ids: set of variable IDs that are currently active (feed into nonlinear primitives)
+            tags: dict mapping variable IDs to their current tag (0=inactive, 1=trial-only, 2=test-only, 3=both); used for trial/test splitting
+            sub_info: dict to store sub-jaxpr analysis results for nested jits; maps eqn IDs to (active_set, resolved_eqns)
+        """
+        self.n_dofs = n_dofs
+        self.active_ids = active_ids
+        self.tags = tags if tags is not None else {}
+        self.dep_of: Dict[int, SparseDepSet] = {}
+        self.val_of: Dict[int, np.ndarray] = {}
+        self.sub_info = sub_info if sub_info is not None else {}
+
+    def set(self, var, d: SparseDepSet) -> None:
+        """Associate dep-set with a JAX variable."""
+        self.dep_of[id(var)] = d
+
+    def get(self, var) -> SparseDepSet:
+        """Get the dep-set of a JAX variable (or return an empty one for literals/unregistered)."""
+        if isinstance(var, Literal):
+            return SparseDepSet.empty(_get_shape(var), self.n_dofs)
+        return self.dep_of.get(
+            id(var), SparseDepSet.empty(_get_shape(var), self.n_dofs)
+        )
+
+    def get_val(self, var) -> np.ndarray | None:
+        """Get the concrete value of a JAX variable if known."""
+        if isinstance(var, Literal):
+            return np.asarray(var.val)
+        return self.val_of.get(id(var))
+
+
+def _analyze_and_resolve_jaxpr(
+    jaxpr,
+    trial_test_split: int | None,
+    tags: Dict[int, int],
+    main_input_id: int | None,
+    sub_info: Dict[int, Any],
+) -> Tuple[List[Tuple[Any, Callable, bool, Any]], Set[int]]:
+    """
+    Performs the forward pass of a unified JAXpr analysis traversal:
+    - Propagates tags (forward)
+    - Identifies nonlinear active equations (forward)
+    - Resolves registered handlers (forward)
+
+    Args:
+        jaxpr: the JAXpr to analyze
+        trial_test_split: if not None, the DOF index at which to split trial vs test variables for nonlinear interaction detection
+        tags: a dict mapping variable IDs to their current tag (0=inactive, 1=trial-only, 2=test-only, 3=both)
+        main_input_id: the variable ID of the main input (e.g., the trial function) to seed with tags; used for trial/test splitting
+        sub_info: a dict to store sub-jaxpr analysis results for nested jits; maps eqn IDs to (active_set, resolved_eqns)
+
+    Returns:
+        A list of forward data tuples: (eqn, handler, is_nonlinear, sub_res)
+        The initial set of active variable IDs seeded from the outputs.
+    """
+    forward_data = []
+    active_set = {id(v) for v in jaxpr.outvars}
+
+    for eqn in jaxpr.eqns:
+        p = eqn.primitive.name
+
+        # propagate tags & JIT recursion
+        sub_res = None
+        if trial_test_split is not None:
+            if (
+                p == "slice"
+                and main_input_id is not None
+                and id(eqn.invars[0]) == main_input_id
+            ):
+                par = eqn.params
+                start = par["start_indices"][0]
+                limit = par["limit_indices"][0]
+                if start == 0 and limit <= trial_test_split:
+                    mask = 1
+                elif start >= trial_test_split:
+                    mask = 2
+                else:
+                    mask = 3
+            elif p in ("pjit", "jit", "scan", "map"):
+                sub_closed = eqn.params["jaxpr"]
+                # Map input tags to sub invars
+                for pv, sv in zip(eqn.invars, sub_closed.jaxpr.invars):
+                    tags[id(sv)] = tags.get(id(pv), 0)
+
+                # Recursively analyze sub-jaxpr
+                sub_eqns, sub_active = _analyze_and_resolve_jaxpr(
+                    sub_closed.jaxpr,
+                    trial_test_split,
+                    tags,
+                    None,
+                    sub_info,
+                )
+                sub_res = (sub_active, sub_eqns)
+
+                # Map output tags back
+                mask = 0
+                for pv, sv in zip(eqn.outvars, sub_closed.jaxpr.outvars):
+                    tags[id(pv)] = tags.get(id(sv), 0)
+                    mask |= tags[id(pv)]
+            else:
+                mask = 0
+                for v in eqn.invars:
+                    mask |= tags.get(id(v), 0)
+
+            for v in eqn.outvars:
+                tags[id(v)] = mask
+        else:
+            if p in ("pjit", "jit", "scan", "map"):
+                sub_closed = eqn.params["jaxpr"]
+                sub_eqns, sub_active = _analyze_and_resolve_jaxpr(
+                    sub_closed.jaxpr,
+                    None,
+                    tags,
+                    None,
+                    sub_info,
+                )
+                sub_res = (sub_active, sub_eqns)
+
+        # check if the equation is a nonlinear primitive
+        is_nonlinear = False
+        if trial_test_split is not None:
+            if p in _NONLINEAR_UNARY:
+                if tags.get(id(eqn.invars[0]), 0) == 3:
+                    is_nonlinear = True
+            elif p in _NONLINEAR_BINARY:
+                combined_mask = 0
+                for v in eqn.invars:
+                    combined_mask |= tags.get(id(v), 0)
+                if combined_mask == 3:
+                    is_nonlinear = True
+            elif p == "integer_pow":
+                exponent = eqn.params.get("y", 0)
+                if exponent >= 2 or exponent <= -1:
+                    if tags.get(id(eqn.invars[0]), 0) == 3:
+                        is_nonlinear = True
+            elif p == "dot_general":
+                combined_mask = 0
+                for v in eqn.invars:
+                    combined_mask |= tags.get(id(v), 0)
+                if combined_mask == 3:
+                    is_nonlinear = True
+            elif p in ("scatter-mul", "scatter_mul"):
+                combined_mask = 0
+                for v in eqn.invars:
+                    combined_mask |= tags.get(id(v), 0)
+                if combined_mask == 3:
+                    is_nonlinear = True
+            elif p in ("pjit", "jit"):
+                pass
+        else:
+            if p in _NONLINEAR_UNARY:
+                is_nonlinear = True
+            elif p in _NONLINEAR_BINARY:
+                is_nonlinear = True
+            elif p == "integer_pow":
+                exponent = eqn.params.get("y", 0)
+                if exponent >= 2 or exponent <= -1:
+                    is_nonlinear = True
+            elif p in ("dot_general", "scatter-mul", "scatter_mul"):
+                is_nonlinear = True
+
+        # Seed active variables if it is a nonlinear primitive
+        if is_nonlinear:
+            for v in eqn.invars:
+                active_set.add(id(v))
+
+        # resolve registered handler
+        handler = TRACER_REGISTRY.get(p, Handlers.fallback)
+
+        forward_data.append(
+            (
+                eqn,
+                handler,
+                is_nonlinear,
+                sub_res if p in ("pjit", "jit", "scan", "map") else None,
+            )
+        )
+
+    return forward_data, active_set
+
+
+def _propagate_active_backward(
+    forward_data: List[Tuple[Any, Callable, bool, Any]],
+    active_set: Set[int],
+    sub_info: Dict[int, Any],
+) -> List[Tuple[Any, Callable, bool]]:
+    """
+    Performs the backward pass of a unified JAXpr analysis traversal:
+    Propagates the active state backwards through the resolved equations list.
+
+    Args:
+        forward_data: the list of forward data tuples (eqn, handler, is_nonlinear, sub_res) from the forward pass
+        active_set: the initial set of active variable IDs seeded from the outputs
+        sub_info: the dict storing sub-jaxpr analysis results for nested jits; maps eqn IDs to (active_set, resolved_eqns)
+
+    Returns:
+        A list of tuples (eqn, handler, is_active) where is_active indicates whether this equation is on an active path.
+    """
+    pruned_eqns = []
+    for eqn, handler, is_nonlinear, sub_res in reversed(forward_data):
+        p = eqn.primitive.name
+        is_active = False
+
+        if p in ("pjit", "jit", "scan", "map"):
+            if any(id(v) in active_set for v in eqn.outvars):
+                is_active = True
+                sub_active_set, sub_eqns = sub_res
+                sub_closed = eqn.params["jaxpr"]
+                sub = sub_closed.jaxpr
+
+                # Map active outvars to sub outvars
+                for pv, sv in zip(eqn.outvars, sub.outvars):
+                    if id(pv) in active_set:
+                        sub_active_set.add(id(sv))
+
+                # Recursively propagate active state backward in sub-jaxpr
+                sub_eqns_pruned = _propagate_active_backward(
+                    sub_eqns, sub_active_set, sub_info
+                )
+
+                # Map active sub invars to parent invars
+                for pv, sv in zip(eqn.invars, sub.invars):
+                    if id(sv) in sub_active_set:
+                        active_set.add(id(pv))
+
+                # Store sub-info for this jit equation
+                sub_info[id(eqn)] = (sub_active_set, sub_eqns_pruned)
+        else:
+            if is_nonlinear or (
+                eqn.outvars and any(id(v) in active_set for v in eqn.outvars)
+            ):
+                is_active = True
+                for v in eqn.invars:
+                    active_set.add(id(v))
+
+        pruned_eqns.append((eqn, handler, is_active))
+
+    pruned_eqns.reverse()
+    return pruned_eqns
+
+
+def _trace_hessian_sparsity(
+    fn: Callable[Concatenate[Array, P], Array],
+    n_dofs: int,
+    *static_args,
+    trial_test_split: int | None = None,
+) -> sps.csr_matrix:
+    """
+    Return the sparsity pattern of d²E/du² (or tangent stiffness matrix K for virtual work formulations)
+    as a CSR matrix.
+    """
+    # Unwrap any outer @jax.jit so static slice indices stay static during tracing
+    fn = _unwrap_jit(fn)
+
+    closed = jax.make_jaxpr(fn)(np.zeros((n_dofs,)), *static_args)
+    jaxpr: Jaxpr = closed.jaxpr
+    consts: Sequence = closed.consts
+
+    # Propagate tags, classify active primitives, and pre-resolve handlers in a single forward-backward pass
+    tags = {}
+    if trial_test_split is not None and jaxpr.invars:
+        tags[id(jaxpr.invars[0])] = 3  # Seed main input with both
+
+    sub_info = {}
+    main_input_id = id(jaxpr.invars[0]) if jaxpr.invars else None
+    forward_data, active_ids = _analyze_and_resolve_jaxpr(
+        jaxpr, trial_test_split, tags, main_input_id, sub_info
+    )
+    bound_eqns = _propagate_active_backward(forward_data, active_ids, sub_info)
+
+    # initialize tracing state
+    state = TraceState(n_dofs, active_ids, tags, sub_info)
+
+    # Seed concrete values of the input variables (essential for dynamic gather/scatter routing of static PyTree params)
+    flat_args, _ = jax.tree_util.tree_flatten((np.zeros((n_dofs,)), *static_args))
+    for invar, arg_val in zip(jaxpr.invars, flat_args):
+        state.val_of[id(invar)] = np.asarray(arg_val)
+
+    # seed: u gets singleton dep-sets; everything else gets empty sets
+    u_seed = SparseDepSet.singletons(n_dofs)
+    if jaxpr.invars:
+        state.set(
+            jaxpr.invars[0], u_seed
+        )  # seed the input variable with singleton dep-sets
+        for v in jaxpr.invars[1:]:
+            state.set(
+                v, SparseDepSet.empty(_get_shape(v), n_dofs)
+            )  # seed other input variables (e.g., static args) with empty dep-sets
+
+    # constants: empty deps but store concrete values for gather routing
+    for v, c in zip(jaxpr.constvars, consts):
+        state.set(v, SparseDepSet.empty(_get_shape(v), n_dofs))
+        state.val_of[id(v)] = np.asarray(c)
+
+    acc = CouplingAccumulator(n_dofs)
+
+    # forward pass: propagate dep-sets through the jaxpr, recording pairs at nonlinear primitives
+    for eqn, handler, is_active in bound_eqns:
+        ovars = eqn.outvars
+        if ovars and not is_active:
+            for v in ovars:
+                state.set(v, SparseDepSet.empty(_get_shape(v), n_dofs))
+            # propagate concrete values (essential for gather/scatter routing indices)
+            in_vals = [state.get_val(v) for v in eqn.invars]
+            cv = _try_concrete(eqn.primitive.name, in_vals, eqn.params)
+            if cv is not None:
+                state.val_of[id(ovars[0])] = cv
+            continue
+
+        handler(eqn, state, acc, trial_test_split)
+
+        # Propagate concrete value for executed equations as well (essential for active gather/scatter routing)
+        if ovars:
+            in_vals = [state.get_val(v) for v in eqn.invars]
+            cv = _try_concrete(eqn.primitive.name, in_vals, eqn.params)
+            if cv is not None:
+                state.val_of[id(ovars[0])] = cv
+
+    pat = acc.finalize()
+    if pat.nnz == 0:
+        return sps.eye(n_dofs, format="csr", dtype=np.int8)
+    return pat
+
+
+def trace_energy_sparsity(
+    energy_fn: Callable[Concatenate[Array, P], Array],
+    n_dofs: int,
+    *static_args,
+) -> sps.csr_matrix:
+    """
+    Return the sparsity pattern of d²E/du² as a symmetric CSR matrix for a scalar energy function E(u)
+    where u has n_dofs degrees of freedom.
+
+    Args:
+        energy_fn   : scalar JAX array energy function E(u, *static_args) as a function of input variable u and optional static arguments
+        n_dofs      : number of DOFs (integer size of flattened input array u)
+        static_args : extra args passed to energy_fn, treated as constants
+
+    Returns:
+        A symmetric CSR matrix of shape (n_dofs, n_dofs) with binary entries indicating the sparsity pattern of the Hessian d²E/du².
+
+    """
+    return _trace_hessian_sparsity(
+        energy_fn, n_dofs, *static_args, trial_test_split=None
+    )
+
+
+def trace_virtual_work_sparsity(
+    virtual_work_fn: Callable[Concatenate[Array, P], Array],
+    n_dofs: int,
+    trial_arg: str,
+    test_arg: str,
+    *static_args,
+) -> sps.csr_matrix:
+    """
+    Return the sparsity pattern of the tangent stiffness matrix K = dR/du = d²G/dvdu
+    for a virtual work function virtual_work_fn(*args) as a CSR matrix.
+
+    Args:
+        virtual_work_fn : scalar JAX array (virtual work) as a function of trial and test variables (e.g., G(u, v, *static_args))
+        n_dofs          : number of DOFs (integer size of flattened input arrays u and v)
+        trial_arg       : parameter name of the trial function in virtual_work_fn
+        test_arg        : parameter name of the test function in virtual_work_fn
+        static_args     : extra arguments (e.g., mesh coordinates, parameters) passed to virtual_work_fn, treated as constants
+
+    Returns:
+        A CSR matrix of shape (n_dofs, n_dofs) with binary entries indicating the sparsity pattern of the tangent stiffness matrix K = dR/du = d²G/dvdu,
+        where G is the virtual work and u,v are the trial and test functions respectively.
+    """
+    # Unwrap any outer @jax.jit so static slice indices stay static during tracing
+    virtual_work_fn = _unwrap_jit(virtual_work_fn)
+
+    combined_dofs = 2 * n_dofs  # combined size of trial and test variables
+
+    # Inspect virtual_work_fn signature to locate trial and test parameter positions
+    sig = inspect.signature(virtual_work_fn)
+    params = list(sig.parameters.keys())
+
+    if trial_arg not in params:
+        raise ValueError(
+            f"Trial argument '{trial_arg}' not found in signature of {virtual_work_fn.__name__}."
+            f"Available parameters: {params}"
+        )
+    if test_arg not in params:
+        raise ValueError(
+            f"Test argument '{test_arg}' not found in signature of {virtual_work_fn.__name__}."
+            f"Available parameters: {params}"
+        )
+
+    trial_idx = params.index(
+        trial_arg
+    )  # position of trial argument in virtual_work_fn signature
+    test_idx = params.index(test_arg)
+
+    def w_fn(w: Array) -> Array:
+        u_val = w[:n_dofs]
+        v_val = w[n_dofs:]
+
+        # Reconstruct the arguments list for virtual_work_fn in the correct order
+        args = []
+        static_iter = iter(static_args)
+        for k, param_name in enumerate(params):
+            if k == trial_idx:
+                args.append(u_val)
+            elif k == test_idx:
+                args.append(v_val)
+            else:
+                try:
+                    args.append(next(static_iter))
+                except StopIteration:
+                    param = sig.parameters[param_name]
+                    if param.default is not inspect.Parameter.empty:
+                        args.append(param.default)
+                    else:
+                        raise ValueError(
+                            f"Missing static argument for parameter '{param_name}' in {virtual_work_fn.__name__}"
+                        )
+
+        return virtual_work_fn(*args)
+
+    # Trace the full Hessian of the combined function w_fn using private helper
+    H_w: sps.csr_matrix = _trace_hessian_sparsity(
+        w_fn, combined_dofs, trial_test_split=n_dofs
+    )
+
+    # Extract the cross-coupling block (v-derivatives vs u-derivatives)
+    K_uv = H_w[n_dofs:, :n_dofs].tocsr()
+    return K_uv
+
+
+# ---------------------------------------------------------------------------
+# concrete value propagation (needed to route gather indices exactly)
+# ---------------------------------------------------------------------------
+
+
+def _try_concrete(p: str, in_vals, par: dict):
+    """Evaluate primitive on numpy values; return None if any input is unknown."""
+    if any(v is None for v in in_vals):
+        return None
+    try:
+        v = [np.asarray(x) for x in in_vals]
+        if p == "add":
+            return np.add(v[0], v[1])
+        if p == "sub":
+            return np.subtract(v[0], v[1])
+        if p == "mul":
+            return np.multiply(v[0], v[1])
+        if p == "div":
+            return np.true_divide(v[0], v[1])
+        if p == "neg":
+            return np.negative(v[0])
+        if p == "abs":
+            return np.abs(v[0])
+        if p == "lt":
+            return np.less(v[0], v[1])
+        if p == "le":
+            return np.less_equal(v[0], v[1])
+        if p == "gt":
+            return np.greater(v[0], v[1])
+        if p == "ge":
+            return np.greater_equal(v[0], v[1])
+        if p == "eq":
+            return np.equal(v[0], v[1])
+        if p == "ne":
+            return np.not_equal(v[0], v[1])
+        if p == "min":
+            return np.minimum(v[0], v[1])
+        if p == "max":
+            return np.maximum(v[0], v[1])
+        if p == "floor":
+            return np.floor(v[0])
+        if p == "ceil":
+            return np.ceil(v[0])
+        if p == "round":
+            return np.round(v[0])
+        if p == "integer_pow":
+            return v[0] ** par["y"]
+        if p == "convert_element_type":
+            return v[0].astype(par["new_dtype"])
+        if p == "reshape":
+            return v[0].reshape(par["new_sizes"])
+        if p == "transpose":
+            return np.transpose(v[0], par["permutation"])
+        if p == "squeeze":
+            return np.squeeze(v[0], axis=tuple(par["dimensions"]))
+        if p == "slice":
+            ss, ls = par["start_indices"], par["limit_indices"]
+            st = par["strides"] or [1] * len(ss)
+            return v[0][tuple(slice(s, l, t) for s, l, t in zip(ss, ls, st))]
+        if p == "concatenate":
+            return np.concatenate(v, axis=par["dimension"])
+        if p == "iota":
+            dim = par["dimension"]
+            shp = par["shape"]
+            newshp = [1] * len(shp)
+            newshp[dim] = shp[dim]
+            return np.broadcast_to(np.arange(shp[dim]).reshape(newshp), shp).copy()
+        if p == "broadcast_in_dim":
+            shape = par["shape"]
+            bdims = par["broadcast_dimensions"]
+            x = v[0]
+            newshp = [1] * len(shape)
+            for i, b in enumerate(bdims):
+                newshp[b] = x.shape[i] if x.ndim > 0 else 1
+            return np.broadcast_to(x.reshape(newshp), shape).copy()
+        if p == "select_n":
+            cond, cases = v[0], v[1:]
+            if len(cases) == 2:
+                return np.where(cond.astype(bool), cases[1], cases[0])
+            result = cases[0].copy()
+            for i, case in enumerate(cases[1:], 1):
+                result = np.where(cond == i, case, result)
+            return result
+    except Exception:
+        pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# JAX primitive propagation handlers namespace class
+# ---------------------------------------------------------------------------
+
+
+class Handlers:
+    """Namespace for primitive dependency propagation handlers."""
+
+    @staticmethod
+    def fallback(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        """Fallback handler for unrecognized primitives."""
+        in_d = [state.get(v) for v in eqn.invars]
+        oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
+
+        cols_active = np.zeros(state.n_dofs, dtype=bool)
+        has_active = False
+        for d in in_d:
+            if isinstance(d, SparseDepSet) and d.dep.shape[0] > 0:
+                cols_active[d.dep.indices] = True
+                has_active = True
+        if not has_active:
+            total = SparseDepSet.empty((), state.n_dofs)
+        else:
+            reduced = sps.csr_matrix(cols_active.reshape(1, -1))
+            total = SparseDepSet(reduced, ())
+        stacked_dep = _broadcast_single_row(total.dep, int(np.prod(oshp)))
+        state.set(eqn.outvars[0], SparseDepSet(stacked_dep, oshp))
+
+    @staticmethod
+    @TRACER_REGISTRY.register("add", "add_any", "sub", "max", "min")
+    def add_sub_max_min(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
+        dep_out = (
+            in_d[0].broadcast_to(oshp).dep + in_d[1].broadcast_to(oshp).dep
+        ).tocsr()
+        dep_out.data[:] = 1
+        state.set(eqn.outvars[0], SparseDepSet(dep_out, oshp))
+
+    @staticmethod
+    @TRACER_REGISTRY.register(
+        "neg", "abs", "convert_element_type", "copy", "stop_gradient", "device_put"
+    )
+    def passthrough(
+        eqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        state.set(eqn.outvars[0], in_d[0].copy())
+
+    @staticmethod
+    @TRACER_REGISTRY.register("broadcast_in_dim")
+    def broadcast(
+        eqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        d = in_d[0]
+        par = eqn.params
+        oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
+        shape = par["shape"]
+        bdims = par["broadcast_dimensions"]
+        if not shape:
+            state.set(eqn.outvars[0], d.copy())
+            return
+        src_indices = np.arange(int(np.prod(d.shape))).reshape(d.shape)
+        new_shape = [1] * len(oshp)
+        for i, b in enumerate(bdims):
+            new_shape[b] = d.shape[i] if i < len(d.shape) else 1
+        mapped_src_indices = np.broadcast_to(
+            src_indices.reshape(new_shape), oshp
+        ).ravel()
+        state.set(eqn.outvars[0], SparseDepSet(d.dep[mapped_src_indices], oshp))
+
+    @staticmethod
+    @TRACER_REGISTRY.register("reshape")
+    def reshape(
+        eqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        ns = eqn.params["new_sizes"]
+        state.set(eqn.outvars[0], in_d[0].reshape(*ns))
+
+    @staticmethod
+    @TRACER_REGISTRY.register("transpose")
+    def transpose(
+        eqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
+        arr_indices = np.arange(int(np.prod(in_d[0].shape))).reshape(in_d[0].shape)
+        perm = np.transpose(arr_indices, eqn.params["permutation"]).ravel()
+        state.set(eqn.outvars[0], SparseDepSet(in_d[0].dep[perm], oshp))
+
+    @staticmethod
+    @TRACER_REGISTRY.register("squeeze")
+    def squeeze(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
+        state.set(eqn.outvars[0], SparseDepSet(in_d[0].dep, oshp))
+
+    @staticmethod
+    @TRACER_REGISTRY.register("slice")
+    def slice(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
+        arr_indices = np.arange(int(np.prod(in_d[0].shape))).reshape(in_d[0].shape)
+        ss, ls = eqn.params["start_indices"], eqn.params["limit_indices"]
+        st = eqn.params["strides"] or [1] * len(ss)
+        slc = tuple(slice(s, l, t) for s, l, t in zip(ss, ls, st))
+        sliced_indices = arr_indices[slc].ravel()
+        state.set(eqn.outvars[0], SparseDepSet(in_d[0].dep[sliced_indices], oshp))
+
+    @staticmethod
+    @TRACER_REGISTRY.register("concatenate")
+    def concatenate(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
+        idx_arrays = []
+        offset = 0
+        for b in in_d:
+            size = int(np.prod(b.shape))
+            idx_arrays.append(np.arange(size).reshape(b.shape) + offset)
+            offset += size
+        stacked_dep = sps.vstack([b.dep for b in in_d], format="csr")
+        concat_idx = np.concatenate(idx_arrays, axis=eqn.params["dimension"]).ravel()
+        state.set(eqn.outvars[0], SparseDepSet(stacked_dep[concat_idx], oshp))
+
+    @staticmethod
+    @TRACER_REGISTRY.register("pad")
+    def pad(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        d = in_d[0]
+        par = eqn.params
+        oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
+        n_dofs = state.n_dofs
+        result_dep = sps.lil_matrix((int(np.prod(oshp)), n_dofs), dtype=bool)
+        if d.dep.shape[0] > 1:
+            result_indices = np.arange(int(np.prod(oshp))).reshape(oshp)
+            slc = tuple(
+                slice(lo, lo + s)
+                for (lo, _, _), s in zip(par["padding_config"], d.shape)
+            )
+            target_indices = result_indices[slc].ravel()
+            result_dep[target_indices] = d.dep
+        state.set(eqn.outvars[0], SparseDepSet(result_dep.tocsr(), oshp))
+
+    @staticmethod
+    @TRACER_REGISTRY.register(
+        "reduce_sum", "reduce_max", "reduce_min", "reduce_and", "reduce_or"
+    )
+    def reduce(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
+        axes = eqn.params["axes"]
+        shape = in_d[0].shape
+        out_indices = np.arange(int(np.prod(oshp))).reshape(oshp)
+        broadcast_shape = list(shape)
+        new_dims = list(oshp)
+        for ax in sorted(axes):
+            new_dims.insert(ax, 1)
+        mapped_out_indices = np.broadcast_to(
+            out_indices.reshape(new_dims), broadcast_shape
+        ).ravel()
+
+        rows = mapped_out_indices
+        cols = np.arange(len(mapped_out_indices))
+        data = np.ones(len(mapped_out_indices), dtype=bool)
+        G = sps.csr_matrix(
+            (data, (rows, cols)), shape=(int(np.prod(oshp)), int(np.prod(shape)))
+        )
+
+        dep_out = (G @ in_d[0].dep).tocsr()
+        dep_out.data[:] = 1
+        state.set(eqn.outvars[0], SparseDepSet(dep_out, oshp))
+
+    @staticmethod
+    @TRACER_REGISTRY.register("select_n")
+    def select_n(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
+        branches = in_d[1:]
+        summed = sum(b.dep for b in branches)
+        dep_out = sps.csr_matrix(summed.astype(bool))  # ty:ignore[unresolved-attribute]
+        state.set(eqn.outvars[0], SparseDepSet(dep_out, oshp))
+
+    @staticmethod
+    @TRACER_REGISTRY.register(
+        "iota",
+        "lt",
+        "le",
+        "gt",
+        "ge",
+        "eq",
+        "ne",
+        "and",
+        "or",
+        "not",
+        "xor",
+        "shift_left",
+        "shift_right_arithmetic",
+        "is_finite",
+        "is_nan",
+        "argmax",
+        "argmin",
+        "floor",
+        "ceil",
+        "round",
+        "sign",
+    )
+    def zero_dependency(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
+        state.set(eqn.outvars[0], SparseDepSet.empty(oshp, state.n_dofs))
+
+    @staticmethod
+    @TRACER_REGISTRY.register(*_NONLINEAR_UNARY)
+    def nonlinear_unary(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        d = in_d[0]
+        state.set(eqn.outvars[0], d.copy())
+        d.record_couplings(acc, trial_test_split)
+
+    @staticmethod
+    @TRACER_REGISTRY.register(*_NONLINEAR_BINARY)
+    def nonlinear_binary(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
+        dep_out = (
+            in_d[0].broadcast_to(oshp).dep + in_d[1].broadcast_to(oshp).dep
+        ).tocsr()
+        dep_out.data[:] = 1
+        combined = SparseDepSet(dep_out, oshp)
+        state.set(eqn.outvars[0], combined)
+
+        is_const0 = in_d[0].dep.nnz == 0
+        is_const1 = in_d[1].dep.nnz == 0
+
+        is_linear = False
+        p = eqn.primitive.name
+        if p == "mul" and (is_const0 or is_const1):
+            is_linear = True
+        elif p == "div" and is_const1:
+            is_linear = True
+
+        if not is_linear:
+            combined.record_couplings(acc, trial_test_split)
+
+    @staticmethod
+    @TRACER_REGISTRY.register("integer_pow")
+    def integer_pow(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        d = in_d[0]
+        state.set(eqn.outvars[0], d.copy())
+        if eqn.params["y"] >= 2 or eqn.params["y"] <= -1:
+            d.record_couplings(acc, trial_test_split)
+
+    @staticmethod
+    @TRACER_REGISTRY.register("gather")
+    def gather(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        d_src = in_d[0]
+        idx = state.get_val(eqn.invars[1])
+        par = eqn.params
+        oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
+
+        if idx is not None and d_src.dep.shape[0] > 1:
+            try:
+                dnums = par["dimension_numbers"]
+                ss = par["slice_sizes"]
+                collapsed = dnums.collapsed_slice_dims
+                sim = dnums.start_index_map
+
+                if collapsed == (0,) and sim == (0,) and ss[0] == 1:
+                    rows = idx.ravel().astype(int)
+                    arr_indices = np.arange(int(np.prod(d_src.shape))).reshape(
+                        d_src.shape
+                    )
+                    slc = (rows,) + tuple(slice(None, s) for s in ss[1:])
+                    flat_src_indices = arr_indices[slc].ravel()
+                    state.set(
+                        eqn.outvars[0], SparseDepSet(d_src.dep[flat_src_indices], oshp)
+                    )
+                    return
+
+                if (
+                    collapsed == (0,)
+                    and sim == (0, 1)
+                    and ss[0] == 1
+                    and idx.ndim == 2
+                    and idx.shape[1] == 2
+                ):
+                    n_gathered = idx.shape[0]
+                    n_cols = ss[1]
+                    arr_indices = np.arange(int(np.prod(d_src.shape))).reshape(
+                        d_src.shape
+                    )
+                    flat_src_indices = []
+                    for k in range(n_gathered):
+                        r = int(idx[k, 0])
+                        c0 = int(idx[k, 1])
+                        flat_src_indices.extend(
+                            arr_indices[r, c0 : c0 + n_cols].tolist()
+                        )
+                    state.set(
+                        eqn.outvars[0], SparseDepSet(d_src.dep[flat_src_indices], oshp)
+                    )
+                    return
+
+                if (
+                    set(collapsed) == set(sim)
+                    and idx.ndim == 2
+                    and idx.shape[1] == len(sim)
+                    and all(ss[a] == 1 for a in sim)
+                ):
+                    n_gathered = idx.shape[0]
+                    arr_indices = np.arange(int(np.prod(d_src.shape))).reshape(
+                        d_src.shape
+                    )
+                    flat_src_indices = []
+                    for k in range(n_gathered):
+                        src_idx = tuple(int(idx[k, j]) for j in range(idx.shape[1]))
+                        flat_src_indices.append(arr_indices[src_idx])
+                    state.set(
+                        eqn.outvars[0], SparseDepSet(d_src.dep[flat_src_indices], oshp)
+                    )
+                    return
+            except Exception:
+                pass
+
+        total = d_src.total_union()
+        stacked_dep = _broadcast_single_row(total.dep, int(np.prod(oshp)))
+        state.set(eqn.outvars[0], SparseDepSet(stacked_dep, oshp))
+
+    @staticmethod
+    @TRACER_REGISTRY.register(
+        "scatter",
+        "scatter-add",
+        "scatter-mul",
+        "scatter-min",
+        "scatter-max",
+        "scatter_add",
+        "scatter_mul",
+        "scatter_min",
+        "scatter_max",
+    )
+    def scatter(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        d_tgt = in_d[0]
+        d_vals = in_d[2]
+        oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
+        p = eqn.primitive.name
+        nonlinear = p in ("scatter-mul", "scatter_mul")
+
+        u_vals = sps.csr_matrix(d_vals.dep.sum(axis=0).astype(bool))
+        idx = state.get_val(eqn.invars[1])
+
+        if idx is not None and d_tgt.dep.shape[0] > 1:
+            try:
+                idx_flat = idx.ravel().astype(int)
+                if len(idx_flat) == d_vals.dep.shape[0]:
+                    # Vectorized precise element-wise scatter routing!
+                    coo_vals = d_vals.dep.tocoo()
+                    row_mapped = idx_flat[coo_vals.row]
+                    valid = (row_mapped >= 0) & (row_mapped < d_tgt.dep.shape[0])
+                    scattered_row = row_mapped[valid]
+                    scattered_col = coo_vals.col[valid]
+                    scattered_data = coo_vals.data[valid]
+
+                    scattered_mat = sps.csr_matrix(
+                        (scattered_data, (scattered_row, scattered_col)),
+                        shape=d_tgt.dep.shape,
+                    )
+                    res_dep = (d_tgt.dep + scattered_mat).tocsr()
+                else:
+                    # Vectorized broadcast scatter routing!
+                    valid_idx = idx_flat[
+                        (idx_flat >= 0) & (idx_flat < d_tgt.dep.shape[0])
+                    ]
+                    if len(valid_idx) > 0:
+                        coo_u = u_vals.tocoo()
+                        u_cols = coo_u.col
+                        u_data = coo_u.data
+
+                        scattered_row = np.repeat(valid_idx, len(u_cols))
+                        scattered_col = np.tile(u_cols, len(valid_idx))
+                        scattered_data = np.tile(u_data, len(valid_idx))
+
+                        scattered_mat = sps.csr_matrix(
+                            (scattered_data, (scattered_row, scattered_col)),
+                            shape=d_tgt.dep.shape,
+                        )
+                        res_dep = (d_tgt.dep + scattered_mat).tocsr()
+                    else:
+                        res_dep = d_tgt.dep.copy()
+
+                res_dep.data[:] = 1
+                res = SparseDepSet(res_dep, oshp)
+                state.set(eqn.outvars[0], res)
+                if nonlinear:
+                    res.record_couplings(acc, trial_test_split)
+                return
+            except Exception:
+                pass
+
+        result = d_tgt.dep + _broadcast_single_row(u_vals, int(np.prod(oshp)))
+        res_dep = result.tocsr()
+        res_dep.data[:] = 1
+        res = SparseDepSet(res_dep, oshp)
+        state.set(eqn.outvars[0], res)
+        if nonlinear:
+            res.record_couplings(acc, trial_test_split)
+
+    @staticmethod
+    @TRACER_REGISTRY.register("dynamic_slice", "dynamic_update_slice")
+    def dynamic_slice(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
+        cols_active = np.zeros(state.n_dofs, dtype=bool)
+        has_active = False
+        for d in in_d:
+            if isinstance(d, SparseDepSet) and d.dep.shape[0] > 0:
+                cols_active[d.dep.indices] = True
+                has_active = True
+        if not has_active:
+            total = SparseDepSet.empty((), state.n_dofs)
+        else:
+            reduced = sps.csr_matrix(cols_active.reshape(1, -1))
+            total = SparseDepSet(reduced, ())
+        stacked_dep = _broadcast_single_row(total.dep, int(np.prod(oshp)))
+        state.set(eqn.outvars[0], SparseDepSet(stacked_dep, oshp))
+
+    @staticmethod
+    @TRACER_REGISTRY.register("dot_general")
+    def dot(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
+
+        # Determine if there is a batch axis
+        dn = eqn.params.get("dimension_numbers")
+        lhs_batch = []
+        rhs_batch = []
+        if dn is not None:
+            if hasattr(dn, "lhs_batch_dimensions"):
+                lhs_batch = dn.lhs_batch_dimensions
+                rhs_batch = dn.rhs_batch_dimensions
+            elif len(dn) > 1:
+                lhs_batch = dn[1][0]
+                rhs_batch = dn[1][1]
+
+        is_batched = False
+        if lhs_batch and rhs_batch:
+            if len(lhs_batch) > 0 and len(rhs_batch) > 0:
+                if lhs_batch[0] == 0 and rhs_batch[0] == 0:
+                    is_batched = True
+
+        if is_batched and len(in_d[0].shape) > 1 and len(in_d[1].shape) > 1:
+            B = in_d[0].shape[0]
+            S_a = int(np.prod(in_d[0].shape[1:]))
+            S_b = int(np.prod(in_d[1].shape[1:]))
+            S_out = int(np.prod(oshp[1:]))
+
+            # Vectorized extraction of active DOFs per batch element
+            coo_a = in_d[0].dep.tocoo()
+            batch_a = coo_a.row // S_a
+            dof_a = coo_a.col
+            A_active = sps.csr_matrix(
+                (np.ones(len(batch_a), dtype=bool), (batch_a, dof_a)),
+                shape=(B, state.n_dofs),
+                dtype=bool,
+            )
+
+            coo_b = in_d[1].dep.tocoo()
+            batch_b = coo_b.row // S_b
+            dof_b = coo_b.col
+            B_active = sps.csr_matrix(
+                (np.ones(len(batch_b), dtype=bool), (batch_b, dof_b)),
+                shape=(B, state.n_dofs),
+                dtype=bool,
+            )
+
+            # Record A and B self-couplings via accumulator (fingerprint-cached)
+            acc.record_dep(A_active, trial_test_split)
+            acc.record_dep(B_active, trial_test_split)
+
+            # Cross-couplings between A and B (no fingerprint cache - structurally distinct)
+            P_cross = (A_active.T @ B_active).tocsr()
+            r_c, c_c = P_cross.nonzero()
+            if trial_test_split is not None:
+                mask_c = (r_c < trial_test_split) & (c_c >= trial_test_split)
+                mask_c |= (r_c >= trial_test_split) & (c_c < trial_test_split)
+                r_c, c_c = r_c[mask_c], c_c[mask_c]
+            acc.add_coords(r_c, c_c)
+            acc.add_coords(c_c, r_c)
+
+            # Vectorized construction of stacked output dependencies
+            C_active = (A_active + B_active).astype(bool).tocsr()
+            repeat_indices = np.repeat(np.arange(B), S_out)
+            stacked_dep = C_active[repeat_indices]
+
+            state.set(eqn.outvars[0], SparseDepSet(stacked_dep, oshp))
+        else:
+            ua = in_d[0].total_union()
+            ub = in_d[1].total_union()
+
+            ua.record_couplings(acc, trial_test_split)
+            ub.record_couplings(acc, trial_test_split)
+
+            ia = ua.dep.indices
+            ib = ub.dep.indices
+            if ia.size and ib.size:
+                # Vectorized outer-product of active DOF indices for cross-couplings
+                r_c = np.repeat(ia, ib.size)
+                c_c = np.tile(ib, ia.size)
+                if trial_test_split is not None:
+                    mask = ((r_c < trial_test_split) & (c_c >= trial_test_split)) | (
+                        (r_c >= trial_test_split) & (c_c < trial_test_split)
+                    )
+                    r_c = r_c[mask]
+                    c_c = c_c[mask]
+                acc.add_coords(r_c, c_c)
+                acc.add_coords(c_c, r_c)
+
+            combined = sps.csr_matrix((ua.dep + ub.dep).astype(bool))
+            stacked_dep = _broadcast_single_row(combined, int(np.prod(oshp)))
+            state.set(eqn.outvars[0], SparseDepSet(stacked_dep, oshp))
+
+    @staticmethod
+    @TRACER_REGISTRY.register("cond", "switch", "while")
+    def control_flow(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        in_d = [state.get(v) for v in eqn.invars]
+        cols_active = np.zeros(state.n_dofs, dtype=bool)
+        has_active = False
+        for d in in_d:
+            if isinstance(d, SparseDepSet) and d.dep.shape[0] > 0:
+                cols_active[d.dep.indices] = True
+                has_active = True
+        if not has_active:
+            total = SparseDepSet.empty((), state.n_dofs)
+        else:
+            reduced = sps.csr_matrix(cols_active.reshape(1, -1))
+            total = SparseDepSet(reduced, ())
+        for ov in eqn.outvars:
+            ov_shape = _get_shape(ov)
+            ov_dep = (
+                _broadcast_single_row(total.dep, int(np.prod(ov_shape)))
+                if ov_shape
+                else total.dep.copy()
+            )
+            state.set(ov, SparseDepSet(ov_dep, ov_shape))
+
+    @staticmethod
+    @TRACER_REGISTRY.register("scan", "map")
+    def scan_map(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        closed_sub = eqn.params["jaxpr"]
+        sub = closed_sub.jaxpr
+        sub_consts = closed_sub.consts
+
+        num_const = eqn.params.get("num_consts", 0)
+        num_carry = eqn.params.get("num_carry", 0)
+        num_xs = len(eqn.invars) - num_const - num_carry
+
+        # Determine local shapes and sizes
+        slice_shapes = []
+        size_slices = []
+        for k in range(num_xs):
+            x = eqn.invars[num_const + num_carry + k]
+            x_dep = state.get(x)
+            slice_shapes.append(x_dep.shape[1:])
+            size_slices.append(int(np.prod(x_dep.shape[1:])))
+
+        # Determine if we have a batch dimension in the slices (e.g. from batched lax.map)
+        batch_size = 1
+        local_size_slices = []
+        for k in range(num_xs):
+            shp = slice_shapes[k]
+            if len(shp) > 1:
+                batch_size = shp[0]
+                local_size_slices.append(int(np.prod(shp[1:])))
+            else:
+                local_size_slices.append(int(np.prod(shp)))
+
+        n_local_dofs = sum(local_size_slices)
+        length = eqn.params.get("length", 1)
+
+        # Seed sub-state with symbolic dependencies for mapped inputs
+        sub_active, sub_bound_eqns = state.sub_info[id(eqn)]
+        sub_state = TraceState(n_local_dofs, sub_active, {}, state.sub_info)
+
+        # Seed consts: empty deps
+        for i in range(num_const):
+            sub_state.set(
+                sub.invars[i],
+                SparseDepSet.empty(_get_shape(sub.invars[i]), n_local_dofs),
+            )
+            val = state.get_val(eqn.invars[i])
+            if val is not None:
+                sub_state.val_of[id(sub.invars[i])] = val
+
+        # Seed consts of the sub-jaxpr
+        for v, c in zip(sub.constvars, sub_consts):
+            sub_state.set(v, SparseDepSet.empty(_get_shape(v), n_local_dofs))
+            sub_state.val_of[id(v)] = np.asarray(c)
+
+        # Seed carry: empty deps
+        for i in range(num_carry):
+            sub_state.set(
+                sub.invars[num_const + i],
+                SparseDepSet.empty(_get_shape(sub.invars[num_const + i]), n_local_dofs),
+            )
+            val = state.get_val(eqn.invars[num_const + i])
+            if val is not None:
+                sub_state.val_of[id(sub.invars[num_const + i])] = val
+
+        # Seed mapped inputs (xs) with symbolic singletons repeated for each batch index
+        symbolic_seed = SparseDepSet.singletons(n_local_dofs)
+        offset = 0
+        for k in range(num_xs):
+            sz = local_size_slices[k]
+            shp = slice_shapes[k]
+            local_dep = symbolic_seed.dep[offset : offset + sz]
+
+            # Repeat local_dep vertically batch_size times to give each batch entry the same symbolic DOFs
+            if batch_size > 1:
+                # local_dep has sz rows, each with a single nnz; tile via direct CSR build
+                local_indptr = local_dep.indptr
+                local_indices = local_dep.indices
+                local_data = local_dep.data
+                # build (batch_size * sz, n_local_dofs) by tiling rows
+                tiled_indices = np.tile(local_indices, batch_size)
+                tiled_data = np.tile(local_data, batch_size)
+                # Each tile has same row-nnz layout; total rows = batch_size * sz
+                base_indptr = local_indptr.copy()
+                base_step = base_indptr[-1]
+                tile_indptrs = [
+                    base_indptr[:-1] + i * base_step for i in range(batch_size)
+                ]
+                tiled_indptr = np.concatenate(
+                    tile_indptrs
+                    + [np.array([batch_size * base_step], dtype=base_indptr.dtype)]
+                )
+                sub_dep = sps.csr_matrix(
+                    (tiled_data, tiled_indices, tiled_indptr),
+                    shape=(batch_size * sz, n_local_dofs),
+                )
+            else:
+                sub_dep = local_dep
+
+            sub_state.set(
+                sub.invars[num_const + num_carry + k], SparseDepSet(sub_dep, shp)
+            )
+
+            # Set a representative concrete value from element 0
+            val = state.get_val(eqn.invars[num_const + num_carry + k])
+            if val is not None and val.shape[0] > 0:
+                sub_state.val_of[id(sub.invars[num_const + num_carry + k])] = val[0]
+
+            offset += sz
+
+        # Trace the sub-jaxpr symbolically using a child accumulator
+        sub_acc = CouplingAccumulator(n_local_dofs)
+        for sub_eqn, sub_handler, sub_is_active in sub_bound_eqns:
+            sub_ovars = sub_eqn.outvars
+            if sub_ovars and not sub_is_active:
+                for v in sub_ovars:
+                    sub_state.set(v, SparseDepSet.empty(_get_shape(v), n_local_dofs))
+                in_vals = [sub_state.get_val(v) for v in sub_eqn.invars]
+                cv = _try_concrete(sub_eqn.primitive.name, in_vals, sub_eqn.params)
+                if cv is not None:
+                    sub_state.val_of[id(sub_ovars[0])] = cv
+                continue
+
+            sub_handler(sub_eqn, sub_state, sub_acc, None)
+
+            if sub_ovars:
+                in_vals = [sub_state.get_val(v) for v in sub_eqn.invars]
+                cv = _try_concrete(sub_eqn.primitive.name, in_vals, sub_eqn.params)
+                if cv is not None:
+                    sub_state.val_of[id(sub_ovars[0])] = cv
+
+        # Extract unique local couplings from the sub-accumulator
+        sub_pat = sub_acc.finalize()
+        sub_r, sub_c = sub_pat.nonzero()
+        unique_couplings = set()
+        for la, lb in zip(sub_r, sub_c):
+            unique_couplings.add((min(int(la), int(lb)), max(int(la), int(lb))))
+
+        # Build local sparse matrices
+        # We group unique_couplings by (k_idx, m_idx)
+        for la, lb in unique_couplings:
+            offset_k = 0
+            k_idx = -1
+            for k in range(num_xs):
+                if offset_k <= la < offset_k + local_size_slices[k]:
+                    k_idx = k
+                    break
+                offset_k += local_size_slices[k]
+
+            offset_m = 0
+            m_idx = -1
+            for m in range(num_xs):
+                if offset_m <= lb < offset_m + local_size_slices[m]:
+                    m_idx = m
+                    break
+                offset_m += local_size_slices[m]
+
+            if k_idx != -1 and m_idx != -1:
+                idx_a = la - offset_k
+                idx_b = lb - offset_m
+
+                dep_x = state.get(eqn.invars[num_const + num_carry + k_idx]).dep
+                dep_y = state.get(eqn.invars[num_const + num_carry + m_idx]).dep
+
+                n_k = local_size_slices[k_idx]
+                n_m = local_size_slices[m_idx]
+
+                col_a = dep_x[idx_a::n_k]
+                col_b = dep_y[idx_b::n_m]
+
+                # Check if we can use the fast direct index mapping (at most 1 nnz per row)
+                nnz_per_row_a = col_a.indptr[1:] - col_a.indptr[:-1]
+                nnz_per_row_b = col_b.indptr[1:] - col_b.indptr[:-1]
+
+                if np.all(nnz_per_row_a <= 1) and np.all(nnz_per_row_b <= 1):
+                    # Direct index mapping (lightning fast, 0 ms!)
+                    active_a = nnz_per_row_a == 1
+                    active_b = nnz_per_row_b == 1
+                    active = active_a & active_b
+
+                    if np.any(active):
+                        c_a = col_a.indices[col_a.indptr[:-1][active]]
+                        c_b = col_b.indices[col_b.indptr[:-1][active]]
+
+                        if trial_test_split is not None:
+                            mask = (c_a < trial_test_split) & (c_b >= trial_test_split)
+                            mask |= (c_a >= trial_test_split) & (c_b < trial_test_split)
+                            c_a = c_a[mask]
+                            c_b = c_b[mask]
+
+                        acc.add_coords(c_a, c_b)
+                        acc.add_coords(c_b, c_a)
+                else:
+                    # Fallback to general sparse matrix multiplication
+                    couplings = (col_a.T @ col_b).tocsr()
+                    r, c = couplings.nonzero()
+                    if trial_test_split is not None:
+                        mask = (r < trial_test_split) & (c >= trial_test_split)
+                        mask |= (r >= trial_test_split) & (c < trial_test_split)
+                        r = r[mask]
+                        c = c[mask]
+                    acc.add_coords(r, c)
+                    acc.add_coords(c, r)
+
+        total_length = length * batch_size
+
+        # Map outputs back to parent state
+        # carry outputs
+        for i in range(num_carry):
+            state.set(
+                eqn.outvars[i],
+                SparseDepSet.empty(_get_shape(eqn.outvars[i]), state.n_dofs),
+            )
+
+        # mapped outputs (ys)
+        if len(eqn.outvars) > num_carry:
+            dep_inputs = [
+                state.get(eqn.invars[num_const + num_carry + k]).dep
+                for k in range(num_xs)
+            ]
+            dep_all = sps.vstack(dep_inputs, format="csr")
+
+            offsets_all = [0]
+            for k in range(num_xs - 1):
+                offsets_all.append(
+                    offsets_all[-1] + total_length * local_size_slices[k]
+                )
+
+            # Vectorized perm_idx construction using NumPy
+            indices_list = []
+            for k in range(num_xs):
+                sz = local_size_slices[k]
+                start_indices = offsets_all[k] + np.arange(total_length) * sz
+                indices_list.append(start_indices[:, None] + np.arange(sz)[None, :])
+            perm_idx = np.hstack(indices_list).ravel()
+
+            In_all = dep_all[perm_idx]
+
+            for i in range(len(eqn.outvars) - num_carry):
+                sub_y = sub.outvars[num_carry + i]
+                y = eqn.outvars[num_carry + i]
+
+                sub_y_dep = sub_state.get(sub_y)
+                slice_shape = sub_y_dep.shape
+
+                sz_local_y = (
+                    int(np.prod(slice_shape[1:]))
+                    if len(slice_shape) > 1
+                    else int(np.prod(slice_shape))
+                )
+
+                # Vectorized sub_y_block construction using NumPy broadcasting instead of a Python loop
+                Y_coo = sub_y_dep.dep.tocoo()
+                if length > 1:
+                    l_arr = np.arange(length)
+                    r_block = (
+                        Y_coo.row[None, :] + l_arr[:, None] * (batch_size * sz_local_y)
+                    ).ravel()
+
+                    base_col = (Y_coo.row // sz_local_y) * n_local_dofs + Y_coo.col
+                    c_block = (
+                        base_col[None, :] + l_arr[:, None] * (batch_size * n_local_dofs)
+                    ).ravel()
+
+                    data_block = np.tile(Y_coo.data, length)
+                else:
+                    r_block = Y_coo.row
+                    c_block = (Y_coo.row // sz_local_y) * n_local_dofs + Y_coo.col
+                    data_block = Y_coo.data
+
+                sub_y_block = sps.csr_matrix(
+                    (data_block, (r_block, c_block)),
+                    shape=(total_length * sz_local_y, total_length * n_local_dofs),
+                )
+
+                expanded_dep = (sub_y_block @ In_all).tocsr()
+                expanded_dep.data[:] = 1
+
+                y_shape = (length,) + slice_shape
+                state.set(y, SparseDepSet(expanded_dep, y_shape))
+
+    @staticmethod
+    @TRACER_REGISTRY.register("pjit", "jit")
+    def subjaxpr(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        closed_sub = eqn.params["jaxpr"]
+        sub = closed_sub.jaxpr
+        sub_consts = closed_sub.consts
+        in_d = [state.get(v) for v in eqn.invars]
+
+        # Retrieve the pre-resolved active set and bound equations for this sub-jaxpr
+        sub_active, sub_bound_eqns = state.sub_info[id(eqn)]
+
+        n_dofs = state.n_dofs
+        sub_state = TraceState(n_dofs, sub_active, state.tags, state.sub_info)
+
+        for v, d in zip(sub.invars, in_d):
+            sub_state.set(v, d)
+        for v, c in zip(sub.constvars, sub_consts):
+            sub_state.set(v, SparseDepSet.empty(_get_shape(v), n_dofs))
+            sub_state.val_of[id(v)] = np.asarray(c)
+
+        for sub_eqn, sub_handler, sub_is_active in sub_bound_eqns:
+            ovars = sub_eqn.outvars
+            if ovars and not sub_is_active:
+                for v in ovars:
+                    sub_state.set(v, SparseDepSet.empty(_get_shape(v), n_dofs))
+                # propagate concrete values (essential for gather/scatter routing indices)
+                in_vals = [sub_state.get_val(v) for v in sub_eqn.invars]
+                cv = _try_concrete(sub_eqn.primitive.name, in_vals, sub_eqn.params)
+                if cv is not None:
+                    sub_state.val_of[id(ovars[0])] = cv
+                continue
+
+            sub_handler(sub_eqn, sub_state, acc, trial_test_split)
+
+            # Propagate concrete value for executed equations as well
+            if ovars:
+                in_vals = [sub_state.get_val(v) for v in sub_eqn.invars]
+                cv = _try_concrete(sub_eqn.primitive.name, in_vals, sub_eqn.params)
+                if cv is not None:
+                    sub_state.val_of[id(ovars[0])] = cv
+
+        for pv, sv in zip(eqn.outvars, sub.outvars):
+            state.set(pv, sub_state.get(sv))

--- a/tatva/sparse/tracer.py
+++ b/tatva/sparse/tracer.py
@@ -108,15 +108,22 @@ class CouplingAccumulator:
         if fp in self._seen_fingerprints:
             return
         self._seen_fingerprints.add(fp)
-        P = (dep.T @ dep).tocsr()
-        r, c = P.nonzero()
         if trial_test_split is not None:
-            mask = ((r < trial_test_split) & (c >= trial_test_split)) | (
-                (r >= trial_test_split) & (c < trial_test_split)
-            )
-            r = r[mask]
-            c = c[mask]
-        self.add_coords(r, c)
+            # Only trial<->test cross couplings survive, so compute just that block
+            # (trial_part.T @ test_part) instead of the full dep.T @ dep over all
+            # columns followed by masking — avoids the discarded self-blocks.
+            s = trial_test_split
+            trial_part = dep[:, :s]
+            test_part = dep[:, s:]
+            cross = (trial_part.T @ test_part).tocsr()
+            r, c = cross.nonzero()
+            c = c + s
+            self.add_coords(r, c)
+            self.add_coords(c, r)
+        else:
+            P = (dep.T @ dep).tocsr()
+            r, c = P.nonzero()
+            self.add_coords(r, c)
 
     def finalize(self) -> sps.csr_matrix:
         """Build the final binary CSR sparsity pattern from the accumulated chunks."""
@@ -1574,16 +1581,17 @@ class Handlers:
                 # build (batch_size * sz, n_local_dofs) by tiling rows
                 tiled_indices = np.tile(local_indices, batch_size)
                 tiled_data = np.tile(local_data, batch_size)
-                # Each tile has same row-nnz layout; total rows = batch_size * sz
-                base_indptr = local_indptr.copy()
-                base_step = base_indptr[-1]
-                tile_indptrs = [
-                    base_indptr[:-1] + i * base_step for i in range(batch_size)
-                ]
+                # Each tile has the same row-nnz layout; total rows = batch_size * sz.
+                # Vectorized tiled indptr: row r of tile i -> local_indptr[r] + i*base_step
+                # (avoids an O(batch_size) Python comprehension).
+                base_step = local_indptr[-1]
+                base = local_indptr[:-1]
+                tiled_indptr = (
+                    base[None, :] + (np.arange(batch_size) * base_step)[:, None]
+                ).ravel()
                 tiled_indptr = np.concatenate(
-                    tile_indptrs
-                    + [np.array([batch_size * base_step], dtype=base_indptr.dtype)]
-                )
+                    [tiled_indptr, np.array([batch_size * base_step])]
+                ).astype(local_indptr.dtype)
                 sub_dep = sps.csr_matrix(
                     (tiled_data, tiled_indices, tiled_indptr),
                     shape=(batch_size * sz, n_local_dofs),
@@ -1623,78 +1631,77 @@ class Handlers:
                 if cv is not None:
                     sub_state.val_of[id(sub_ovars[0])] = cv
 
-        # Extract unique local couplings from the sub-accumulator
+        # Extract unique local couplings from the sub-accumulator. sub_pat.nonzero()
+        # already yields unique (r, c); canonicalize to (lo, hi) and dedup via a scipy
+        # sparse round-trip (np.unique is slow on Python >= 3.13).
         sub_pat = sub_acc.finalize()
         sub_r, sub_c = sub_pat.nonzero()
-        unique_couplings = set()
-        for la, lb in zip(sub_r, sub_c):
-            unique_couplings.add((min(int(la), int(lb)), max(int(la), int(lb))))
+        if sub_r.size:
+            lo = np.minimum(sub_r, sub_c)
+            hi = np.maximum(sub_r, sub_c)
+            canon = sps.csr_matrix(
+                (np.ones(lo.size, dtype=bool), (lo, hi)),
+                shape=(n_local_dofs, n_local_dofs),
+            )
+            lo_arr, hi_arr = canon.nonzero()
+        else:
+            lo_arr = hi_arr = np.empty(0, dtype=np.intp)
 
-        # Build local sparse matrices
-        # We group unique_couplings by (k_idx, m_idx)
-        for la, lb in unique_couplings:
-            offset_k = 0
-            k_idx = -1
-            for k in range(num_xs):
-                if offset_k <= la < offset_k + local_size_slices[k]:
-                    k_idx = k
-                    break
-                offset_k += local_size_slices[k]
+        # Cumulative offsets to locate which mapped input owns a local index, plus a
+        # per-local-index cache of strided column slices (the same local index recurs
+        # across many coupling pairs, so slicing once avoids redundant CSR fancy-indexing).
+        offsets = np.concatenate(([0], np.cumsum(local_size_slices)))
+        slice_cache: Dict[int, Tuple[sps.csr_matrix, np.ndarray]] = {}
 
-            offset_m = 0
-            m_idx = -1
-            for m in range(num_xs):
-                if offset_m <= lb < offset_m + local_size_slices[m]:
-                    m_idx = m
-                    break
-                offset_m += local_size_slices[m]
+        def _get_col(local_idx: int) -> Tuple[sps.csr_matrix, np.ndarray]:
+            cached = slice_cache.get(local_idx)
+            if cached is not None:
+                return cached
+            k_idx = int(np.searchsorted(offsets, local_idx, side="right")) - 1
+            idx_in = local_idx - int(offsets[k_idx])
+            n_k = local_size_slices[k_idx]
+            dep_x = state.get(eqn.invars[num_const + num_carry + k_idx]).dep
+            col = dep_x[idx_in::n_k]
+            nnz_per_row = col.indptr[1:] - col.indptr[:-1]
+            cached = (col, nnz_per_row)
+            slice_cache[local_idx] = cached
+            return cached
 
-            if k_idx != -1 and m_idx != -1:
-                idx_a = la - offset_k
-                idx_b = lb - offset_m
+        # Build local sparse matrices for each unique (canonicalized) coupling pair
+        for la, lb in zip(lo_arr.tolist(), hi_arr.tolist()):
+            col_a, nnz_per_row_a = _get_col(la)
+            col_b, nnz_per_row_b = _get_col(lb)
 
-                dep_x = state.get(eqn.invars[num_const + num_carry + k_idx]).dep
-                dep_y = state.get(eqn.invars[num_const + num_carry + m_idx]).dep
+            # Check if we can use the fast direct index mapping (at most 1 nnz per row)
+            if np.all(nnz_per_row_a <= 1) and np.all(nnz_per_row_b <= 1):
+                # Direct index mapping (lightning fast, 0 ms!)
+                active_a = nnz_per_row_a == 1
+                active_b = nnz_per_row_b == 1
+                active = active_a & active_b
 
-                n_k = local_size_slices[k_idx]
-                n_m = local_size_slices[m_idx]
+                if np.any(active):
+                    c_a = col_a.indices[col_a.indptr[:-1][active]]
+                    c_b = col_b.indices[col_b.indptr[:-1][active]]
 
-                col_a = dep_x[idx_a::n_k]
-                col_b = dep_y[idx_b::n_m]
-
-                # Check if we can use the fast direct index mapping (at most 1 nnz per row)
-                nnz_per_row_a = col_a.indptr[1:] - col_a.indptr[:-1]
-                nnz_per_row_b = col_b.indptr[1:] - col_b.indptr[:-1]
-
-                if np.all(nnz_per_row_a <= 1) and np.all(nnz_per_row_b <= 1):
-                    # Direct index mapping (lightning fast, 0 ms!)
-                    active_a = nnz_per_row_a == 1
-                    active_b = nnz_per_row_b == 1
-                    active = active_a & active_b
-
-                    if np.any(active):
-                        c_a = col_a.indices[col_a.indptr[:-1][active]]
-                        c_b = col_b.indices[col_b.indptr[:-1][active]]
-
-                        if trial_test_split is not None:
-                            mask = (c_a < trial_test_split) & (c_b >= trial_test_split)
-                            mask |= (c_a >= trial_test_split) & (c_b < trial_test_split)
-                            c_a = c_a[mask]
-                            c_b = c_b[mask]
-
-                        acc.add_coords(c_a, c_b)
-                        acc.add_coords(c_b, c_a)
-                else:
-                    # Fallback to general sparse matrix multiplication
-                    couplings = (col_a.T @ col_b).tocsr()
-                    r, c = couplings.nonzero()
                     if trial_test_split is not None:
-                        mask = (r < trial_test_split) & (c >= trial_test_split)
-                        mask |= (r >= trial_test_split) & (c < trial_test_split)
-                        r = r[mask]
-                        c = c[mask]
-                    acc.add_coords(r, c)
-                    acc.add_coords(c, r)
+                        mask = (c_a < trial_test_split) & (c_b >= trial_test_split)
+                        mask |= (c_a >= trial_test_split) & (c_b < trial_test_split)
+                        c_a = c_a[mask]
+                        c_b = c_b[mask]
+
+                    acc.add_coords(c_a, c_b)
+                    acc.add_coords(c_b, c_a)
+            else:
+                # Fallback to general sparse matrix multiplication
+                couplings = (col_a.T @ col_b).tocsr()
+                r, c = couplings.nonzero()
+                if trial_test_split is not None:
+                    mask = (r < trial_test_split) & (c >= trial_test_split)
+                    mask |= (r >= trial_test_split) & (c < trial_test_split)
+                    r = r[mask]
+                    c = c[mask]
+                acc.add_coords(r, c)
+                acc.add_coords(c, r)
 
         total_length = length * batch_size
 

--- a/tatva/sparse/tracer.py
+++ b/tatva/sparse/tracer.py
@@ -42,6 +42,20 @@ def _get_shape(var: Var | Literal) -> Tuple[int, ...]:
     return getattr(var.aval, "shape", ())
 
 
+def _subjaxpr_and_consts(eqn) -> Tuple[Jaxpr, Sequence]:
+    """Normalize the ``jaxpr`` param of a single-subgraph higher-order primitive.
+
+    ``pjit``/``jit``/``scan``/``map`` store a ``ClosedJaxpr`` (``.jaxpr`` + ``.consts``),
+    whereas ``remat2`` (``jax.checkpoint``) stores a bare ``Jaxpr`` with no consts.
+    Both expose the same 1:1 invar/outvar correspondence with the parent equation, so
+    this returns ``(jaxpr, consts)`` for either form.
+    """
+    sub = eqn.params["jaxpr"]
+    if hasattr(sub, "jaxpr"):  # ClosedJaxpr
+        return sub.jaxpr, sub.consts
+    return sub, ()
+
+
 def _unwrap_jit(fn):
     """Recursively unwrap `@jax.jit` / `@pjit` decorators only.
 
@@ -361,15 +375,15 @@ def _analyze_and_resolve_jaxpr(
                     mask = 2
                 else:
                     mask = 3
-            elif p in ("pjit", "jit", "scan", "map"):
-                sub_closed = eqn.params["jaxpr"]
+            elif p in ("pjit", "jit", "scan", "map", "remat2"):
+                sub_jaxpr, _ = _subjaxpr_and_consts(eqn)
                 # Map input tags to sub invars
-                for pv, sv in zip(eqn.invars, sub_closed.jaxpr.invars):
+                for pv, sv in zip(eqn.invars, sub_jaxpr.invars):
                     tags[id(sv)] = tags.get(id(pv), 0)
 
                 # Recursively analyze sub-jaxpr
                 sub_eqns, sub_active = _analyze_and_resolve_jaxpr(
-                    sub_closed.jaxpr,
+                    sub_jaxpr,
                     trial_test_split,
                     tags,
                     None,
@@ -379,7 +393,7 @@ def _analyze_and_resolve_jaxpr(
 
                 # Map output tags back
                 mask = 0
-                for pv, sv in zip(eqn.outvars, sub_closed.jaxpr.outvars):
+                for pv, sv in zip(eqn.outvars, sub_jaxpr.outvars):
                     tags[id(pv)] = tags.get(id(sv), 0)
                     mask |= tags[id(pv)]
             elif p == "cond":
@@ -406,10 +420,10 @@ def _analyze_and_resolve_jaxpr(
             for v in eqn.outvars:
                 tags[id(v)] = mask
         else:
-            if p in ("pjit", "jit", "scan", "map"):
-                sub_closed = eqn.params["jaxpr"]
+            if p in ("pjit", "jit", "scan", "map", "remat2"):
+                sub_jaxpr, _ = _subjaxpr_and_consts(eqn)
                 sub_eqns, sub_active = _analyze_and_resolve_jaxpr(
-                    sub_closed.jaxpr,
+                    sub_jaxpr,
                     None,
                     tags,
                     None,
@@ -441,13 +455,12 @@ def _analyze_and_resolve_jaxpr(
                 if exponent >= 2 or exponent <= -1:
                     if tags.get(id(eqn.invars[0]), 0) == 3:
                         is_nonlinear = True
-            elif p == "dot_general":
-                combined_mask = 0
-                for v in eqn.invars:
-                    combined_mask |= tags.get(id(v), 0)
-                if combined_mask == 3:
-                    is_nonlinear = True
-            elif p in ("scatter-mul", "scatter_mul"):
+            elif p in (
+                "dot_general",
+                "scatter-mul",
+                "custom_vjp_call",
+                "custom_jvp_call",
+            ):
                 combined_mask = 0
                 for v in eqn.invars:
                     combined_mask |= tags.get(id(v), 0)
@@ -464,7 +477,12 @@ def _analyze_and_resolve_jaxpr(
                 exponent = eqn.params.get("y", 0)
                 if exponent >= 2 or exponent <= -1:
                     is_nonlinear = True
-            elif p in ("dot_general", "scatter-mul", "scatter_mul"):
+            elif p in (
+                "dot_general",
+                "scatter-mul",
+                "custom_vjp_call",
+                "custom_jvp_call",
+            ):
                 is_nonlinear = True
 
         # Seed active variables if it is a nonlinear primitive
@@ -480,7 +498,9 @@ def _analyze_and_resolve_jaxpr(
                 eqn,
                 handler,
                 is_nonlinear,
-                sub_res if p in ("pjit", "jit", "scan", "map", "cond") else None,
+                sub_res
+                if p in ("pjit", "jit", "scan", "map", "remat2", "cond")
+                else None,
             )
         )
 
@@ -509,12 +529,11 @@ def _propagate_active_backward(
         p = eqn.primitive.name
         is_active = False
 
-        if p in ("pjit", "jit", "scan", "map"):
+        if p in ("pjit", "jit", "scan", "map", "remat2"):
             if any(id(v) in active_set for v in eqn.outvars):
                 is_active = True
                 sub_active_set, sub_eqns = sub_res
-                sub_closed = eqn.params["jaxpr"]
-                sub = sub_closed.jaxpr
+                sub, _ = _subjaxpr_and_consts(eqn)
 
                 # Map active outvars to sub outvars
                 for pv, sv in zip(eqn.outvars, sub.outvars):
@@ -901,7 +920,13 @@ class Handlers:
 
     @staticmethod
     @TRACER_REGISTRY.register(
-        "neg", "abs", "convert_element_type", "copy", "stop_gradient", "device_put"
+        "neg",
+        "abs",
+        "convert_element_type",
+        "copy",
+        "stop_gradient",
+        "device_put",
+        "conj",
     )
     def passthrough(
         eqn,
@@ -1262,13 +1287,10 @@ class Handlers:
     @TRACER_REGISTRY.register(
         "scatter",
         "scatter-add",
+        "scatter-sub",
         "scatter-mul",
         "scatter-min",
         "scatter-max",
-        "scatter_add",
-        "scatter_mul",
-        "scatter_min",
-        "scatter_max",
     )
     def scatter(
         eqn: JaxprEqn,
@@ -1281,7 +1303,7 @@ class Handlers:
         d_vals = in_d[2]
         oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
         p = eqn.primitive.name
-        nonlinear = p in ("scatter-mul", "scatter_mul")
+        nonlinear = p == "scatter-mul"
 
         u_vals = sps.csr_matrix(d_vals.dep.sum(axis=0).astype(bool))
         idx = state.get_val(eqn.invars[1])
@@ -1474,6 +1496,20 @@ class Handlers:
         acc: "CouplingAccumulator",
         trial_test_split: int | None,
     ) -> None:
+        """Conservative fallback for control-flow primitives.
+
+        Unions the input dependencies into every output element without descending
+        into the carried jaxpr, so it propagates first-order dependencies but records
+        no second-order couplings of its own. ``cond`` is handled precisely by the
+        dedicated ``cond`` handler (which overrides this registration); ``switch``
+        lowers to ``cond``, so in practice only ``while`` reaches here.
+
+        The missing couplings are not reachable for the Hessian use case: a ``while``
+        appearing inside an energy would have to be double-differentiable to contribute
+        to the Hessian, but ``lax.while_loop`` is not reverse-mode differentiable in JAX
+        (this is precisely why iterative solvers are wrapped in ``custom_vjp`` /
+        implicit differentiation, which is handled by ``custom_vjp_jvp_call`` instead).
+        """
         in_d = [state.get(v) for v in eqn.invars]
         cols_active = np.zeros(state.n_dofs, dtype=bool)
         has_active = False
@@ -1780,16 +1816,21 @@ class Handlers:
                 state.set(y, SparseDepSet(expanded_dep, y_shape))
 
     @staticmethod
-    @TRACER_REGISTRY.register("pjit", "jit")
+    @TRACER_REGISTRY.register("pjit", "jit", "remat2")
     def subjaxpr(
         eqn: JaxprEqn,
         state: TraceState,
         acc: "CouplingAccumulator",
         trial_test_split: int | None,
     ) -> None:
-        closed_sub = eqn.params["jaxpr"]
-        sub = closed_sub.jaxpr
-        sub_consts = closed_sub.consts
+        """Trace a single carried sub-jaxpr (``pjit``/``jit``/``remat2``).
+
+        ``remat2`` (``jax.checkpoint``) is just a memory-recompute wrapper around an
+        ordinary computation: descending into its jaxpr records the couplings created
+        inside exactly as for ``pjit``. Treating it as opaque (fallback) would silently
+        drop those couplings and under-count the Hessian.
+        """
+        sub, sub_consts = _subjaxpr_and_consts(eqn)
         in_d = [state.get(v) for v in eqn.invars]
 
         # Retrieve the pre-resolved active set and bound equations for this sub-jaxpr
@@ -1903,3 +1944,42 @@ class Handlers:
             state.set(
                 ov, d if d is not None else SparseDepSet.empty(_get_shape(ov), n_dofs)
             )
+
+    @staticmethod
+    @TRACER_REGISTRY.register("custom_vjp_call", "custom_jvp_call")
+    def custom_vjp_jvp_call(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        """Handler for JAX custom_vjp and custom_jvp calls.
+        These represent general nonlinear black-box functions.
+        We propagate the union of input dependencies to each output element,
+        and record the self-couplings of the inputs (since they are nonlinear).
+        Since the internal structure of the custom call is opaque, we couple all inputs
+        together even if internals are linear.
+        """
+        in_d = [state.get(v) for v in eqn.invars]
+
+        # 1. Accumulate all input active columns to record couplings
+        cols_active = np.zeros(state.n_dofs, dtype=bool)
+        has_active = False
+        for d in in_d:
+            if isinstance(d, SparseDepSet) and d.dep.shape[0] > 0:
+                cols_active[d.dep.indices] = True
+                has_active = True
+
+        if not has_active:
+            total = SparseDepSet.empty((), state.n_dofs)
+        else:
+            reduced = sps.csr_matrix(cols_active.reshape(1, -1))
+            total = SparseDepSet(reduced, ())
+            # Record couplings for the active input DOFs
+            acc.record_dep(total.dep, trial_test_split)
+
+        # 2. Set the dependency set for all output variables
+        for ovar in eqn.outvars:
+            oshp = _get_shape(ovar)
+            stacked_dep = _broadcast_single_row(total.dep, int(np.prod(oshp)))
+            state.set(ovar, SparseDepSet(stacked_dep, oshp))

--- a/tatva/sparse/tracer.py
+++ b/tatva/sparse/tracer.py
@@ -1,10 +1,19 @@
-"""
-Determine the Hessian sparsity pattern of a scalar JAX function E(u)
-by propagating ancestor-DOF sets through the *forward* computational graph.
-This is implemented as a custom JAX tracer that tracks the dependency of each
-intermediate variable on the input DOFs, and records pairs of DOFs that interact nonlinearly in the graph.
-
-"""
+# Copyright (C) 2025 ETH Zurich (SMEC)
+#
+# This file is part of tatva.
+#
+# tatva is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# tatva is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with tatva.  If not, see <https://www.gnu.org/licenses/>.
 
 import inspect
 from typing import (
@@ -366,6 +375,22 @@ def _analyze_and_resolve_jaxpr(
                 for pv, sv in zip(eqn.outvars, sub_closed.jaxpr.outvars):
                     tags[id(pv)] = tags.get(id(sv), 0)
                     mask |= tags[id(pv)]
+            elif p == "cond":
+                # cond carries one jaxpr per branch; invars[0] is the predicate and
+                # invars[1:] are the operands passed to every branch.
+                operands = eqn.invars[1:]
+                sub_res = []
+                mask = 0
+                for branch in eqn.params["branches"]:
+                    bj = branch.jaxpr
+                    for pv, sv in zip(operands, bj.invars):
+                        tags[id(sv)] = tags.get(id(pv), 0)
+                    sub_eqns, sub_active = _analyze_and_resolve_jaxpr(
+                        bj, trial_test_split, tags, None, sub_info
+                    )
+                    sub_res.append((sub_active, sub_eqns))
+                    for sv in bj.outvars:
+                        mask |= tags.get(id(sv), 0)
             else:
                 mask = 0
                 for v in eqn.invars:
@@ -384,6 +409,13 @@ def _analyze_and_resolve_jaxpr(
                     sub_info,
                 )
                 sub_res = (sub_active, sub_eqns)
+            elif p == "cond":
+                sub_res = []
+                for branch in eqn.params["branches"]:
+                    sub_eqns, sub_active = _analyze_and_resolve_jaxpr(
+                        branch.jaxpr, None, tags, None, sub_info
+                    )
+                    sub_res.append((sub_active, sub_eqns))
 
         # check if the equation is a nonlinear primitive
         is_nonlinear = False
@@ -441,7 +473,7 @@ def _analyze_and_resolve_jaxpr(
                 eqn,
                 handler,
                 is_nonlinear,
-                sub_res if p in ("pjit", "jit", "scan", "map") else None,
+                sub_res if p in ("pjit", "jit", "scan", "map", "cond") else None,
             )
         )
 
@@ -494,6 +526,33 @@ def _propagate_active_backward(
 
                 # Store sub-info for this jit equation
                 sub_info[id(eqn)] = (sub_active_set, sub_eqns_pruned)
+        elif p == "cond":
+            if any(id(v) in active_set for v in eqn.outvars):
+                is_active = True
+                operands = eqn.invars[1:]
+                pruned_branches = []
+                for (sub_active_set, sub_eqns), branch in zip(
+                    sub_res, eqn.params["branches"]
+                ):
+                    sub = branch.jaxpr
+
+                    # Map active outvars to each branch's outvars
+                    for pv, sv in zip(eqn.outvars, sub.outvars):
+                        if id(pv) in active_set:
+                            sub_active_set.add(id(sv))
+
+                    sub_eqns_pruned = _propagate_active_backward(
+                        sub_eqns, sub_active_set, sub_info
+                    )
+
+                    # Map active branch invars back to the cond operands (invars[1:])
+                    for pv, sv in zip(operands, sub.invars):
+                        if id(sv) in sub_active_set:
+                            active_set.add(id(pv))
+
+                    pruned_branches.append((sub_active_set, sub_eqns_pruned))
+
+                sub_info[id(eqn)] = pruned_branches
         else:
             if is_nonlinear or (
                 eqn.outvars and any(id(v) in active_set for v in eqn.outvars)
@@ -1762,3 +1821,79 @@ class Handlers:
 
         for pv, sv in zip(eqn.outvars, sub.outvars):
             state.set(pv, sub_state.get(sv))
+
+    @staticmethod
+    @TRACER_REGISTRY.register("cond")
+    def cond(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        """Trace each branch of a ``cond``/``switch`` and union the outputs.
+
+        Unlike the conservative ``control_flow`` fallback, this traverses every branch
+        jaxpr — recording the couplings created *inside* a branch into the shared
+        accumulator — and propagates the OR of all branches' output dependency sets. A
+        piecewise function's derivative is one branch's, so unioning the branches is an
+        AD-safe superset. The predicate (``invars[0]``) only selects and contributes no
+        couplings, so it is ignored.
+        """
+        operands = eqn.invars[1:]
+        in_d = [state.get(v) for v in operands]
+        n_dofs = state.n_dofs
+        branch_sub_list = state.sub_info[id(eqn)]
+
+        out_deps: Dict[int, SparseDepSet | None] = {id(ov): None for ov in eqn.outvars}
+        for (sub_active, sub_bound_eqns), branch in zip(
+            branch_sub_list, eqn.params["branches"]
+        ):
+            sub = branch.jaxpr
+            sub_consts = branch.consts
+            sub_state = TraceState(n_dofs, sub_active, state.tags, state.sub_info)
+
+            # Seed branch invars with operand dep-sets and concrete values (the latter
+            # are needed to route any gather/scatter indices inside the branch).
+            for sv, d, ov in zip(sub.invars, in_d, operands):
+                sub_state.set(sv, d)
+                val = state.get_val(ov)
+                if val is not None:
+                    sub_state.val_of[id(sv)] = val
+            for v, c in zip(sub.constvars, sub_consts):
+                sub_state.set(v, SparseDepSet.empty(_get_shape(v), n_dofs))
+                sub_state.val_of[id(v)] = np.asarray(c)
+
+            for sub_eqn, sub_handler, sub_is_active in sub_bound_eqns:
+                ovars = sub_eqn.outvars
+                if ovars and not sub_is_active:
+                    for v in ovars:
+                        sub_state.set(v, SparseDepSet.empty(_get_shape(v), n_dofs))
+                    in_vals = [sub_state.get_val(v) for v in sub_eqn.invars]
+                    cv = _try_concrete(sub_eqn.primitive.name, in_vals, sub_eqn.params)
+                    if cv is not None:
+                        sub_state.val_of[id(ovars[0])] = cv
+                    continue
+
+                sub_handler(sub_eqn, sub_state, acc, trial_test_split)
+
+                if ovars:
+                    in_vals = [sub_state.get_val(v) for v in sub_eqn.invars]
+                    cv = _try_concrete(sub_eqn.primitive.name, in_vals, sub_eqn.params)
+                    if cv is not None:
+                        sub_state.val_of[id(ovars[0])] = cv
+
+            for ov, sv in zip(eqn.outvars, sub.outvars):
+                d = sub_state.get(sv)
+                prev = out_deps[id(ov)]
+                if prev is None:
+                    out_deps[id(ov)] = d
+                else:
+                    merged = (prev.dep + d.dep).tocsr()
+                    merged.data[:] = 1
+                    out_deps[id(ov)] = SparseDepSet(merged, d.shape)
+
+        for ov in eqn.outvars:
+            d = out_deps[id(ov)]
+            state.set(
+                ov, d if d is not None else SparseDepSet.empty(_get_shape(ov), n_dofs)
+            )

--- a/tatva/sparse/tracer.py
+++ b/tatva/sparse/tracer.py
@@ -16,17 +16,8 @@
 # along with tatva.  If not, see <https://www.gnu.org/licenses/>.
 
 import inspect
-from typing import (
-    Any,
-    Callable,
-    Concatenate,
-    Dict,
-    List,
-    ParamSpec,
-    Sequence,
-    Set,
-    Tuple,
-)
+from collections.abc import Callable, Sequence
+from typing import Any, Concatenate, ParamSpec
 
 import jax
 import numpy as np
@@ -37,12 +28,13 @@ from jax.extend.core import Jaxpr, JaxprEqn, Literal, Var
 P = ParamSpec("P")
 
 
-def _get_shape(var: Var | Literal) -> Tuple[int, ...]:
-    """Helper to safely retrieve shape from a JAX Var/Literal abstract value (satisfying static type checkers)."""
+def _get_shape(var: Var | Literal) -> tuple[int, ...]:
+    """Helper to safely retrieve shape from a JAX Var/Literal abstract value (satisfying
+    static type checkers)."""
     return getattr(var.aval, "shape", ())
 
 
-def _subjaxpr_and_consts(eqn) -> Tuple[Jaxpr, Sequence]:
+def _subjaxpr_and_consts(eqn) -> tuple[Jaxpr, Sequence]:
     """Normalize the ``jaxpr`` param of a single-subgraph higher-order primitive.
 
     ``pjit``/``jit``/``scan``/``map`` store a ``ClosedJaxpr`` (``.jaxpr`` + ``.consts``),
@@ -89,13 +81,14 @@ def _broadcast_single_row(row: sps.csr_matrix, N: int) -> sps.csr_matrix:
 
 
 class CouplingAccumulator:
-    """Accumulates Hessian coupling pairs as numpy-array chunks; fingerprints dep matrices to skip redundant recordings."""
+    """Accumulates Hessian coupling pairs as numpy-array chunks; fingerprints dep matrices
+    to skip redundant recordings."""
 
     def __init__(self, n_dofs: int):
         self.n_dofs = n_dofs
-        self._row_chunks: List[np.ndarray] = []
-        self._col_chunks: List[np.ndarray] = []
-        self._seen_fingerprints: Set[int] = set()
+        self._row_chunks: list[np.ndarray] = []
+        self._col_chunks: list[np.ndarray] = []
+        self._seen_fingerprints: set[int] = set()
 
     def add_coords(self, rows: np.ndarray, cols: np.ndarray) -> None:
         """Append a chunk of coordinate pairs without converting to Python lists."""
@@ -107,7 +100,8 @@ class CouplingAccumulator:
     def record_dep(
         self, dep: sps.csr_matrix, trial_test_split: int | None = None
     ) -> None:
-        """Compute dep.T @ dep couplings; skip if an identical dep structure has already been recorded."""
+        """Compute dep.T @ dep couplings; skip if an identical dep structure has already
+        been recorded."""
         if dep.nnz == 0:
             return
         # Fingerprint: identical (indptr, indices) + split → identical couplings
@@ -233,7 +227,7 @@ TRACER_REGISTRY = TracerRegistry()
 # solver vmapped over quad points. Declaring a target here lets the tracer recover the
 # sparse (block-diagonal) coupling from the single batched ``ffi_call`` instead of the
 # conservative dense couple-all. See ``register_elementwise_ffi``.
-_ELEMENTWISE_FFI_TARGETS: Set[str] = set()
+_ELEMENTWISE_FFI_TARGETS: set[str] = set()
 
 
 def register_elementwise_ffi(*target_names: str) -> None:
@@ -263,8 +257,8 @@ class SparseDepSet:
 
         Args:
             dep: sps.csr_matrix of shape (prod(shape), n_dofs) with boolean data
-            shape: logical shape of the array this dep-set corresponds to (e.g., (3,4) for a 3×4 array);
-                   the dep-array is always flattened in row-major order
+            shape: logical shape of the array this dep-set corresponds to (e.g., (3,4) for
+                a 3×4 array); the dep-array is always flattened in row-major order
         """
         self.dep = dep  # sps.csr_matrix of shape (prod(shape), n_dofs)
         self.shape = tuple(shape)
@@ -284,7 +278,8 @@ class SparseDepSet:
 
     @classmethod
     def singletons(cls, n_dofs: int) -> "SparseDepSet":
-        """Create an identity-seeded SparseDepSet of shape (n_dofs,) where element i depends only on DOF i."""
+        """Create an identity-seeded SparseDepSet of shape (n_dofs,) where element i
+        depends only on DOF i."""
         dep = sps.eye(n_dofs, format="csr", dtype=bool)
         return cls(dep, (n_dofs,))
 
@@ -319,22 +314,25 @@ class TraceState:
     def __init__(
         self,
         n_dofs: int,
-        active_ids: Set[int],
+        active_ids: set[int],
         tags: dict | None = None,
         sub_info: dict | None = None,
     ):
         """
         Args:
             n_dofs: total number of DOFs (size of the input variable)
-            active_ids: set of variable IDs that are currently active (feed into nonlinear primitives)
-            tags: dict mapping variable IDs to their current tag (0=inactive, 1=trial-only, 2=test-only, 3=both); used for trial/test splitting
-            sub_info: dict to store sub-jaxpr analysis results for nested jits; maps eqn IDs to (active_set, resolved_eqns)
+            active_ids: set of variable IDs that are currently active (feed into nonlinear
+                primitives)
+            tags: dict mapping variable IDs to their current tag (0=inactive,
+                1=trial-only, 2=test-only, 3=both); used for trial/test splitting
+            sub_info: dict to store sub-jaxpr analysis results for nested jits; maps eqn
+                IDs to (active_set, resolved_eqns)
         """
         self.n_dofs = n_dofs
         self.active_ids = active_ids
         self.tags = tags if tags is not None else {}
-        self.dep_of: Dict[int, SparseDepSet] = {}
-        self.val_of: Dict[int, np.ndarray] = {}
+        self.dep_of: dict[int, SparseDepSet] = {}
+        self.val_of: dict[int, np.ndarray] = {}
         self.sub_info = sub_info if sub_info is not None else {}
 
     def set(self, var, d: SparseDepSet) -> None:
@@ -359,10 +357,10 @@ class TraceState:
 def _analyze_and_resolve_jaxpr(
     jaxpr,
     trial_test_split: int | None,
-    tags: Dict[int, int],
+    tags: dict[int, int],
     main_input_id: int | None,
-    sub_info: Dict[int, Any],
-) -> Tuple[List[Tuple[Any, Callable, bool, Any]], Set[int]]:
+    sub_info: dict[int, Any],
+) -> tuple[list[tuple[Any, Callable, bool, Any]], set[int]]:
     """
     Performs the forward pass of a unified JAXpr analysis traversal:
     - Propagates tags (forward)
@@ -371,10 +369,14 @@ def _analyze_and_resolve_jaxpr(
 
     Args:
         jaxpr: the JAXpr to analyze
-        trial_test_split: if not None, the DOF index at which to split trial vs test variables for nonlinear interaction detection
-        tags: a dict mapping variable IDs to their current tag (0=inactive, 1=trial-only, 2=test-only, 3=both)
-        main_input_id: the variable ID of the main input (e.g., the trial function) to seed with tags; used for trial/test splitting
-        sub_info: a dict to store sub-jaxpr analysis results for nested jits; maps eqn IDs to (active_set, resolved_eqns)
+        trial_test_split: if not None, the DOF index at which to split trial vs test
+            variables for nonlinear interaction detection
+        tags: a dict mapping variable IDs to their current tag (0=inactive, 1=trial-only,
+            2=test-only, 3=both)
+        main_input_id: the variable ID of the main input (e.g., the trial function) to
+            seed with tags; used for trial/test splitting
+        sub_info: a dict to store sub-jaxpr analysis results for nested jits; maps eqn IDs
+            to (active_set, resolved_eqns)
 
     Returns:
         A list of forward data tuples: (eqn, handler, is_nonlinear, sub_res)
@@ -542,21 +544,24 @@ def _analyze_and_resolve_jaxpr(
 
 
 def _propagate_active_backward(
-    forward_data: List[Tuple[Any, Callable, bool, Any]],
-    active_set: Set[int],
-    sub_info: Dict[int, Any],
-) -> List[Tuple[Any, Callable, bool]]:
+    forward_data: list[tuple[Any, Callable, bool, Any]],
+    active_set: set[int],
+    sub_info: dict[int, Any],
+) -> list[tuple[Any, Callable, bool]]:
     """
     Performs the backward pass of a unified JAXpr analysis traversal:
     Propagates the active state backwards through the resolved equations list.
 
     Args:
-        forward_data: the list of forward data tuples (eqn, handler, is_nonlinear, sub_res) from the forward pass
+        forward_data: the list of forward data tuples (eqn, handler, is_nonlinear,
+            sub_res) from the forward pass
         active_set: the initial set of active variable IDs seeded from the outputs
-        sub_info: the dict storing sub-jaxpr analysis results for nested jits; maps eqn IDs to (active_set, resolved_eqns)
+        sub_info: the dict storing sub-jaxpr analysis results for nested jits; maps eqn
+            IDs to (active_set, resolved_eqns)
 
     Returns:
-        A list of tuples (eqn, handler, is_active) where is_active indicates whether this equation is on an active path.
+        A list of tuples (eqn, handler, is_active) where is_active indicates whether this
+        equation is on an active path.
     """
     pruned_eqns = []
     for eqn, handler, is_nonlinear, sub_res in reversed(forward_data):
@@ -633,10 +638,8 @@ def _trace_hessian_sparsity(
     *static_args,
     trial_test_split: int | None = None,
 ) -> sps.csr_matrix:
-    """
-    Return the sparsity pattern of d²E/du² (or tangent stiffness matrix K for virtual work formulations)
-    as a CSR matrix.
-    """
+    """Return the sparsity pattern of d²E/du² (or tangent stiffness matrix K for virtual
+    work formulations) as a CSR matrix."""
     # Unwrap any outer @jax.jit so static slice indices stay static during tracing
     fn = _unwrap_jit(fn)
 
@@ -716,16 +719,18 @@ def pattern_from_energy(
     *static_args,
 ) -> sps.csr_matrix:
     """
-    Return the sparsity pattern of d²E/du² as a symmetric CSR matrix for a scalar energy function E(u)
-    where u has n_dofs degrees of freedom.
+    Return the sparsity pattern of d²E/du² as a symmetric CSR matrix for a scalar energy
+    function E(u) where u has n_dofs degrees of freedom.
 
     Args:
-        energy_fn: scalar JAX array energy function E(u, *static_args) as a function of input variable u and optional static arguments
+        energy_fn: scalar JAX array energy function E(u, *static_args) as a function of
+            input variable u and optional static arguments
         n_dofs: number of DOFs (integer size of flattened input array u)
         static_args: extra args passed to energy_fn, treated as constants
 
     Returns:
-        A symmetric CSR matrix of shape (n_dofs, n_dofs) with binary entries indicating the sparsity pattern of the Hessian d²E/du².
+        A symmetric CSR matrix of shape (n_dofs, n_dofs) with binary entries indicating
+        the sparsity pattern of the Hessian d²E/du².
     """
     return _trace_hessian_sparsity(
         energy_fn, n_dofs, *static_args, trial_test_split=None
@@ -744,15 +749,18 @@ def pattern_from_virtual_work(
     for a virtual work function virtual_work_fn(*args) as a CSR matrix.
 
     Args:
-        virtual_work_fn : scalar JAX array (virtual work) as a function of trial and test variables (e.g., G(u, v, *static_args))
-        n_dofs          : number of DOFs (integer size of flattened input arrays u and v)
-        trial_arg       : parameter name of the trial function in virtual_work_fn
-        test_arg        : parameter name of the test function in virtual_work_fn
-        static_args     : extra arguments (e.g., mesh coordinates, parameters) passed to virtual_work_fn, treated as constants
+        virtual_work_fn: scalar JAX array (virtual work) as a function of trial and test
+            variables (e.g., G(u, v, *static_args))
+        n_dofs: number of DOFs (integer size of flattened input arrays u and v)
+        trial_arg: parameter name of the trial function in virtual_work_fn
+        test_arg: parameter name of the test function in virtual_work_fn
+        static_args: extra arguments (e.g., mesh coordinates, parameters) passed to
+            virtual_work_fn, treated as constants
 
     Returns:
-        A CSR matrix of shape (n_dofs, n_dofs) with binary entries indicating the sparsity pattern of the tangent stiffness matrix K = dR/du = d²G/dvdu,
-        where G is the virtual work and u,v are the trial and test functions respectively.
+        A CSR matrix of shape (n_dofs, n_dofs) with binary entries indicating the sparsity
+        pattern of the tangent stiffness matrix K = dR/du = d²G/dvdu, where G is the
+        virtual work and u,v are the trial and test functions respectively.
     """
     # Unwrap any outer @jax.jit so static slice indices stay static during tracing
     virtual_work_fn = _unwrap_jit(virtual_work_fn)
@@ -1740,9 +1748,9 @@ class Handlers:
         # per-local-index cache of strided column slices (the same local index recurs
         # across many coupling pairs, so slicing once avoids redundant CSR fancy-indexing).
         offsets = np.concatenate(([0], np.cumsum(local_size_slices)))
-        slice_cache: Dict[int, Tuple[sps.csr_matrix, np.ndarray]] = {}
+        slice_cache: dict[int, tuple[sps.csr_matrix, np.ndarray]] = {}
 
-        def _get_col(local_idx: int) -> Tuple[sps.csr_matrix, np.ndarray]:
+        def _get_col(local_idx: int) -> tuple[sps.csr_matrix, np.ndarray]:
             cached = slice_cache.get(local_idx)
             if cached is not None:
                 return cached
@@ -1945,7 +1953,7 @@ class Handlers:
         n_dofs = state.n_dofs
         branch_sub_list = state.sub_info[id(eqn)]
 
-        out_deps: Dict[int, SparseDepSet | None] = {id(ov): None for ov in eqn.outvars}
+        out_deps: dict[int, SparseDepSet | None] = {id(ov): None for ov in eqn.outvars}
         for (sub_active, sub_bound_eqns), branch in zip(
             branch_sub_list, eqn.params["branches"]
         ):

--- a/tatva/sparse/tracer.py
+++ b/tatva/sparse/tracer.py
@@ -228,6 +228,34 @@ class TracerRegistry:
 TRACER_REGISTRY = TracerRegistry()
 
 
+# FFI targets whose vmapped (batched) call is elementwise along the leading (vmap) axis,
+# i.e. output[i] depends only on input[i] -- e.g. a per-quad-point external constitutive
+# solver vmapped over quad points. Declaring a target here lets the tracer recover the
+# sparse (block-diagonal) coupling from the single batched ``ffi_call`` instead of the
+# conservative dense couple-all. See ``register_elementwise_ffi``.
+_ELEMENTWISE_FFI_TARGETS: Set[str] = set()
+
+
+def register_elementwise_ffi(*target_names: str) -> None:
+    """Declare one or more ``jax.ffi`` target names as elementwise along the vmap axis.
+
+    A vmapped ``ffi_call`` is a *single* batched custom-call over the whole leading axis,
+    so by default the tracer must treat it as a dense opaque block (it cannot tell the
+    batch axis is independent). Registering the target tells the tracer that the call is a
+    per-element map (output[i] depends only on input[i]) -- as it is for a per-quad-point
+    external solver vmapped over quad points -- so it records conservative coupling *per
+    slice* (block-diagonal across the leading axis), recovering the sparse pattern.
+
+    Register by the FFI target name (the string passed to ``jax.ffi.ffi_call``) -- anyone
+    building or using a ``jax.ffi`` solver knows this name. Then a per-quad-point external
+    solver vmapped over quad points, ``jax.vmap(solver)(strain_field)``, traces sparse.
+
+    Only register a target if this independence genuinely holds; otherwise real
+    cross-element couplings would be silently missed.
+    """
+    _ELEMENTWISE_FFI_TARGETS.update(target_names)
+
+
 class SparseDepSet:
     def __init__(self, dep: sps.csr_matrix, shape: tuple):
         """
@@ -460,6 +488,9 @@ def _analyze_and_resolve_jaxpr(
                 "scatter-mul",
                 "custom_vjp_call",
                 "custom_jvp_call",
+                "pure_callback",
+                "io_callback",
+                "ffi_call",
             ):
                 combined_mask = 0
                 for v in eqn.invars:
@@ -482,6 +513,9 @@ def _analyze_and_resolve_jaxpr(
                 "scatter-mul",
                 "custom_vjp_call",
                 "custom_jvp_call",
+                "pure_callback",
+                "io_callback",
+                "ffi_call",
             ):
                 is_nonlinear = True
 
@@ -885,6 +919,10 @@ class Handlers:
         trial_test_split: int | None,
     ) -> None:
         """Fallback handler for unrecognized primitives."""
+        if not eqn.outvars:
+            # Effect-only primitive (no array outputs), e.g. a debug/print callback.
+            # Nothing to propagate and nothing couples through it.
+            return
         in_d = [state.get(v) for v in eqn.invars]
         oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
 
@@ -901,6 +939,22 @@ class Handlers:
             total = SparseDepSet(reduced, ())
         stacked_dep = _broadcast_single_row(total.dep, int(np.prod(oshp)))
         state.set(eqn.outvars[0], SparseDepSet(stacked_dep, oshp))
+
+    @staticmethod
+    @TRACER_REGISTRY.register("debug_print", "debug_callback")
+    def no_op(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        """Effect-only debug primitives (``jax.debug.print`` / ``jax.debug.callback``).
+
+        They have no array outputs and contribute nothing to the Hessian, so the tracer
+        simply skips them -- letting you sprinkle ``jax.debug.print`` into an energy or
+        virtual-work form for debugging without breaking sparsity tracing.
+        """
+        return
 
     @staticmethod
     @TRACER_REGISTRY.register("add", "add_any", "sub", "max", "min")
@@ -1946,19 +2000,30 @@ class Handlers:
             )
 
     @staticmethod
-    @TRACER_REGISTRY.register("custom_vjp_call", "custom_jvp_call")
+    @TRACER_REGISTRY.register(
+        "custom_vjp_call",
+        "custom_jvp_call",
+        "pure_callback",
+        "io_callback",
+    )
     def custom_vjp_jvp_call(
         eqn: JaxprEqn,
         state: TraceState,
         acc: "CouplingAccumulator",
         trial_test_split: int | None,
     ) -> None:
-        """Handler for JAX custom_vjp and custom_jvp calls.
-        These represent general nonlinear black-box functions.
-        We propagate the union of input dependencies to each output element,
-        and record the self-couplings of the inputs (since they are nonlinear).
-        Since the internal structure of the custom call is opaque, we couple all inputs
-        together even if internals are linear.
+        """Handler for JAX custom_vjp/custom_jvp calls and host callbacks
+        (``pure_callback`` / ``io_callback``).
+
+        These all represent general nonlinear black-box functions whose internals are
+        opaque to the tracer (a host callback has no traceable jaxpr at all; an external
+        RVE solver typically lives inside one wrapped in ``custom_jvp``). We therefore
+        propagate the union of input dependencies to each output element and record the
+        self-couplings of the active inputs, coupling all inputs together even if the
+        internals happen to be linear. This is conservative (over-approximate): it can
+        never miss a coupling, which is the correct failure mode for an unseen black box.
+        Note the plain ``fallback`` handler does NOT record couplings, so an external
+        callback that landed there would silently drop them.
         """
         in_d = [state.get(v) for v in eqn.invars]
 
@@ -1983,3 +2048,66 @@ class Handlers:
             oshp = _get_shape(ovar)
             stacked_dep = _broadcast_single_row(total.dep, int(np.prod(oshp)))
             state.set(ovar, SparseDepSet(stacked_dep, oshp))
+
+    @staticmethod
+    @TRACER_REGISTRY.register("ffi_call")
+    def ffi_call(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        """Handler for ``jax.ffi.ffi_call`` (external XLA custom-call solvers).
+
+        Default: an opaque black box -> couple all active inputs (same conservative rule
+        as ``custom_vjp_jvp_call``). Note a *vmapped* ffi_call is a SINGLE batched call
+        over the whole leading axis, so this default over-approximates it to a dense block.
+
+        Opt-in (``register_elementwise_ffi(target)``): treat the call as elementwise along
+        the leading (vmap) axis -- couple inputs *per slice* (block-diagonal across that
+        axis) so a per-quad-point external solver vmapped over quad points keeps its sparse
+        pattern, exactly as it would via ``lax.map``/``scan``.
+        """
+        in_d = [state.get(v) for v in eqn.invars]
+        target = eqn.params.get("target_name")
+
+        # Decide whether the block-diagonal (elementwise) rule applies: the target must be
+        # registered AND every operand must share a common leading (batch) axis.
+        lead = None
+        if target in _ELEMENTWISE_FFI_TARGETS:
+            shapes = [d.shape for d in in_d] + [_get_shape(ov) for ov in eqn.outvars]
+            if shapes and all(len(s) >= 1 for s in shapes):
+                leads = {s[0] for s in shapes}
+                if len(leads) == 1:
+                    lead = leads.pop()
+
+        if not lead:
+            # Conservative default: opaque couple-all over every active input.
+            Handlers.custom_vjp_jvp_call(eqn, state, acc, trial_test_split)
+            return
+
+        B = lead
+        # Per-slice union of input columns, recorded as an independent coupling block.
+        slice_rows: list[sps.csr_matrix] = []
+        for b in range(B):
+            cols_active = np.zeros(state.n_dofs, dtype=bool)
+            for d in in_d:
+                nrows = d.dep.shape[0]
+                if nrows == 0:
+                    continue
+                core = nrows // B
+                blk = d.dep[b * core : (b + 1) * core]
+                if blk.nnz:
+                    cols_active[blk.indices] = True
+            row = sps.csr_matrix(cols_active.reshape(1, -1))
+            if row.nnz:
+                acc.record_dep(row, trial_test_split)
+            slice_rows.append(row)
+
+        # Assign each output: slice b broadcast over its core (per-slice) elements.
+        for ovar in eqn.outvars:
+            oshp = _get_shape(ovar)
+            core_o = int(np.prod(oshp)) // B
+            blocks = [_broadcast_single_row(slice_rows[b], core_o) for b in range(B)]
+            stacked = sps.vstack(blocks).tocsr()
+            state.set(ovar, SparseDepSet(stacked, oshp))

--- a/tatva/sparse/tracer.py
+++ b/tatva/sparse/tracer.py
@@ -657,7 +657,7 @@ def _trace_hessian_sparsity(
     return pat
 
 
-def trace_energy_sparsity(
+def pattern_from_energy(
     energy_fn: Callable[Concatenate[Array, P], Array],
     n_dofs: int,
     *static_args,
@@ -667,20 +667,19 @@ def trace_energy_sparsity(
     where u has n_dofs degrees of freedom.
 
     Args:
-        energy_fn   : scalar JAX array energy function E(u, *static_args) as a function of input variable u and optional static arguments
-        n_dofs      : number of DOFs (integer size of flattened input array u)
-        static_args : extra args passed to energy_fn, treated as constants
+        energy_fn: scalar JAX array energy function E(u, *static_args) as a function of input variable u and optional static arguments
+        n_dofs: number of DOFs (integer size of flattened input array u)
+        static_args: extra args passed to energy_fn, treated as constants
 
     Returns:
         A symmetric CSR matrix of shape (n_dofs, n_dofs) with binary entries indicating the sparsity pattern of the Hessian d²E/du².
-
     """
     return _trace_hessian_sparsity(
         energy_fn, n_dofs, *static_args, trial_test_split=None
     )
 
 
-def trace_virtual_work_sparsity(
+def pattern_from_virtual_work(
     virtual_work_fn: Callable[Concatenate[Array, P], Array],
     n_dofs: int,
     trial_arg: str,

--- a/tatva/utils.py
+++ b/tatva/utils.py
@@ -140,8 +140,8 @@ def make_project_function(
     """
     from tatva.sparse import ColoredMatrix
     from tatva.sparse._extraction import (
+        _adapt_sparsity_with_lifter,
         _create_sparse_structure,
-        reduce_sparsity_pattern,
     )
 
     if colored_matrix is None:
@@ -152,7 +152,7 @@ def make_project_function(
         n = nnodes * dim
         sp = _create_sparse_structure(elements, dim, (n, n))
         if lifter is not None:
-            sp = reduce_sparsity_pattern(sp, lifter.free_dofs)
+            sp = _adapt_sparsity_with_lifter(sp, lifter)
         colored_matrix = ColoredMatrix.from_csr(sp)
     else:
         dim = colored_matrix.shape[0] // nnodes

--- a/tests/test_allreduce_benchmark.py
+++ b/tests/test_allreduce_benchmark.py
@@ -66,9 +66,8 @@ def _build_problem(nx, ny, rank, size, comm):
     )
     lifter = Lifter(n_dofs, Fixed(fixed_dofs, 0.0))
 
-    free_sparsity = sparse.reduce_sparsity_pattern(
-        sparse.create_sparsity_pattern(raw_mesh, N_DOFS_PER_NODE),
-        lifter.free_dofs,
+    free_sparsity = lifter.adapt_sparsity(
+        sparse.pattern_from_mesh(raw_mesh, N_DOFS_PER_NODE)
     )
     global_colored = sparse.ColoredMatrix.from_csr(free_sparsity)
 

--- a/tests/test_colored_matrix_benchmark.py
+++ b/tests/test_colored_matrix_benchmark.py
@@ -24,8 +24,9 @@ import pytest
 import scipy.sparse as sp
 from jax import Array
 from jax_autovmap import autovmap
+
 from tatva import Mesh, Operator, element
-from tatva.sparse import ColoredMatrix, create_sparsity_pattern, jacfwd
+from tatva.sparse import ColoredMatrix, jacfwd, pattern_from_mesh
 
 jax.config.update("jax_enable_x64", True)
 
@@ -75,7 +76,7 @@ def _build_problem(
 
     grad_fn = jax.grad(energy_fn)
 
-    sparsity = create_sparsity_pattern(mesh, 2)
+    sparsity = pattern_from_mesh(mesh, 2)
 
     return op, energy_fn, grad_fn, sparsity, n_dofs
 

--- a/tests/test_operator_projection.py
+++ b/tests/test_operator_projection.py
@@ -2,6 +2,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+
 from tatva import Mesh, Operator, element, sparse
 
 jax.config.update("jax_enable_x64", True)
@@ -23,7 +24,7 @@ def test_project_scalar_field(op, mesh):
     field = quad_points[:, :, 0] + quad_points[:, :, 1]
 
     # Project with scalar matrix
-    sp = sparse.create_sparsity_pattern(mesh, 1)
+    sp = sparse.pattern_from_mesh(mesh, 1)
     cm = sparse.ColoredMatrix.from_csr(sp)
 
     projected = op.project(field, cm)
@@ -39,7 +40,7 @@ def test_project_vector_field(op, mesh):
     field = quad_points  # (E, Q, 2)
 
     # Project with scalar matrix (Multiple RHS solve)
-    sp_scalar = sparse.create_sparsity_pattern(mesh, 1)
+    sp_scalar = sparse.pattern_from_mesh(mesh, 1)
     cm_scalar = sparse.ColoredMatrix.from_csr(sp_scalar)
     projected_scalar = op.project(field, cm_scalar)
 
@@ -47,7 +48,7 @@ def test_project_vector_field(op, mesh):
     np.testing.assert_allclose(projected_scalar, mesh.coords, atol=1e-7)
 
     # Project with vector matrix (Coupled solve)
-    sp_vector = sparse.create_sparsity_pattern(mesh, 2)
+    sp_vector = sparse.pattern_from_mesh(mesh, 2)
     cm_vector = sparse.ColoredMatrix.from_csr(sp_vector)
     projected_vector = op.project(field, cm_vector)
 
@@ -64,7 +65,7 @@ def test_project_tensor_field(op, mesh):
     field = field.at[:, :, 1, 1].set(quad_points[:, :, 1])
 
     # Project with scalar matrix (4 independent RHS)
-    sp = sparse.create_sparsity_pattern(mesh, 1)
+    sp = sparse.pattern_from_mesh(mesh, 1)
     cm = sparse.ColoredMatrix.from_csr(sp)
 
     projected = op.project(field, cm)

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -58,7 +58,7 @@ def test_sparse_matrix(op: Operator, coloring_func):
 
     K = jax.jacfwd(jax.jacrev(total_energy))(jnp.zeros(op.mesh.coords.shape[0] * 2))
 
-    sparsity_pattern_csr = sparse.create_sparsity_pattern(op.mesh, n_dofs_per_node=2)
+    sparsity_pattern_csr = sparse.pattern_from_mesh(op.mesh, n_dofs_per_node=2)
     indptr = sparsity_pattern_csr.indptr
     indices = sparsity_pattern_csr.indices
 

--- a/tests/test_sparse_benchmark.py
+++ b/tests/test_sparse_benchmark.py
@@ -81,7 +81,7 @@ def _build_problem(
     def total_energy_with_args(u_flat: Array, damage: Array) -> Array:
         return total_energy(u_flat) * jnp.mean(damage)
 
-    sparsity_pattern_csr = sparse.create_sparsity_pattern(mesh, n_dofs_per_node=2)
+    sparsity_pattern_csr = sparse.pattern_from_mesh(mesh, n_dofs_per_node=2)
 
     colors = distance2_color_and_seeds(
         row_ptr=sparsity_pattern_csr.indptr,

--- a/tests/test_sparse_tracer.py
+++ b/tests/test_sparse_tracer.py
@@ -526,3 +526,107 @@ def test_unsymmetric_sparsity(line_operator):
 
     # Two interleaved nodal fields are traced conservatively, so require no false negatives.
     _assert_traced_matches(pat, K_pat, my_lifter, exact=False)
+
+
+# ---------------------------------------------------------------------------
+# external (opaque) constitutive leaves: custom_jvp + lax.map, and ffi_call + vmap
+# ---------------------------------------------------------------------------
+
+
+def test_custom_jvp_leaf_virtual_work_matches_connectivity(line_operator):
+    """An external constitutive leaf wrapped in ``custom_jvp`` and mapped per quad point
+    with ``lax.map`` (a scan the tracer descends into) keeps the correct sparse tangent
+    pattern -- identical to the pure-JAX linear-elastic connectivity."""
+    N = 6
+    op = line_operator(N)
+
+    class Field(compound.Compound, mesh=op.mesh):
+        u = compound.field((FieldSize.AUTO, 1))
+
+    @jax.custom_jvp
+    def stress_qp(strain):  # per quad point: (n_dim,) -> (n_dim,)
+        return 2.0 * strain
+
+    @stress_qp.defjvp
+    def stress_qp_jvp(primals, tangents):
+        (s,), (ds,) = primals, tangents
+        return stress_qp(s), 2.0 * ds
+
+    def stress(strain):
+        nd = strain.shape[-1]
+        return jax.lax.map(stress_qp, strain.reshape(-1, nd)).reshape(strain.shape)
+
+    def g_leaf(w, u):
+        (u_n,) = Field(u)
+        (w_n,) = Field(w)
+        return op.integrate(
+            jnp.einsum("eqd,eqd->eq", stress(op.grad(u_n)), op.grad(w_n))
+        ).sum()
+
+    def g_elastic(w, u):
+        (u_n,) = Field(u)
+        (w_n,) = Field(w)
+        return op.integrate(
+            jnp.einsum("eqd,eqd->eq", 2.0 * op.grad(u_n), op.grad(w_n))
+        ).sum()
+
+    ref = pattern_from_virtual_work(g_elastic, Field.size, trial_arg="u", test_arg="w")
+    pat = pattern_from_virtual_work(g_leaf, Field.size, trial_arg="u", test_arg="w")
+    assert nz_set(pat) == nz_set(ref)
+
+
+def test_ffi_leaf_virtual_work_register_elementwise(line_operator):
+    """A vmapped ``ffi_call`` constitutive leaf is global-dense by default; declaring the
+    target with ``register_elementwise_ffi`` recovers the elastic-connectivity pattern.
+    Pattern-only: the FFI is never executed during tracing."""
+    import jax.ffi as jffi
+
+    from tatva.sparse import register_elementwise_ffi
+    from tatva.sparse.tracer import _ELEMENTWISE_FFI_TARGETS
+
+    N = 6
+    op = line_operator(N)
+
+    class Field(compound.Compound, mesh=op.mesh):
+        u = compound.field((FieldSize.AUTO, 1))
+
+    target = "tatva_fem_test_rve"
+
+    def stress_qp(s):  # (n_dim,) -> (n_dim,)
+        return jffi.ffi_call(
+            target, jax.ShapeDtypeStruct(s.shape, s.dtype), vmap_method="broadcast_all"
+        )(s)
+
+    def stress(strain):
+        nd = strain.shape[-1]
+        return jax.vmap(stress_qp)(strain.reshape(-1, nd)).reshape(strain.shape)
+
+    def g_leaf(w, u):
+        (u_n,) = Field(u)
+        (w_n,) = Field(w)
+        return op.integrate(
+            jnp.einsum("eqd,eqd->eq", stress(op.grad(u_n)), op.grad(w_n))
+        ).sum()
+
+    def g_elastic(w, u):
+        (u_n,) = Field(u)
+        (w_n,) = Field(w)
+        return op.integrate(
+            jnp.einsum("eqd,eqd->eq", op.grad(u_n), op.grad(w_n))
+        ).sum()
+
+    ref = pattern_from_virtual_work(g_elastic, Field.size, trial_arg="u", test_arg="w")
+    try:
+        assert target not in _ELEMENTWISE_FFI_TARGETS
+        dense = pattern_from_virtual_work(
+            g_leaf, Field.size, trial_arg="u", test_arg="w"
+        )
+        # default: opaque batched call -> strictly denser than (a superset of) the truth
+        assert nz_set(ref) <= nz_set(dense)
+        assert dense.nnz > ref.nnz
+
+        register_elementwise_ffi(target)
+        pat = pattern_from_virtual_work(g_leaf, Field.size, trial_arg="u", test_arg="w")
+        assert nz_set(pat) == nz_set(ref)
+    finally:
+        _ELEMENTWISE_FFI_TARGETS.discard(target)

--- a/tests/test_sparse_tracer.py
+++ b/tests/test_sparse_tracer.py
@@ -1,0 +1,482 @@
+from dataclasses import replace
+from typing import NamedTuple
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import scipy.sparse as sps
+from jax import Array
+from jax_autovmap import autovmap
+
+from tatva import Mesh, Operator, compound, element, lifter, sparse
+from tatva.compound import FieldSize
+from tatva.sparse import trace_energy_sparsity, trace_virtual_work_sparsity
+
+jax.config.update("jax_enable_x64", True)
+
+
+def nz_set(m: sps.spmatrix) -> set[tuple[int, int]]:
+    """Convert a sparse matrix to a set of ``(row, col)`` nonzero index tuples."""
+    r, c = m.nonzero()  # ty:ignore[unresolved-attribute]
+    return set(zip(r.tolist(), c.tolist()))
+
+
+def create_rectangle_box_tetrahedron_mesh(
+    lengths: tuple[float, float, float], nb_elems: tuple[int, int, int]
+) -> Mesh:
+    """Build a structured tetrahedral mesh of a rectangular box (6 tets per hex cell)."""
+    x_length, y_length, z_length = lengths
+    nx, ny, nz = nb_elems
+
+    x_rng = np.linspace(-x_length / 2, x_length / 2, nx + 1)
+    y_rng = np.linspace(-y_length / 2, y_length / 2, ny + 1)
+    z_rng = np.linspace(0, z_length, nz + 1)
+
+    Z, Y, X = np.meshgrid(z_rng, y_rng, x_rng, indexing="ij")
+    nodes = np.stack([X, Y, Z], axis=-1).reshape(-1, 3)
+
+    stride_x = 1
+    stride_y = nx + 1
+    stride_z = (nx + 1) * (ny + 1)
+
+    k_idx, j_idx, i_idx = np.meshgrid(
+        np.arange(nz), np.arange(ny), np.arange(nx), indexing="ij"
+    )
+    n0 = (i_idx * stride_x + j_idx * stride_y + k_idx * stride_z).flatten()
+
+    n1 = n0 + stride_x
+    n2 = n0 + stride_y
+    n3 = n2 + stride_x
+    n4 = n0 + stride_z
+    n5 = n4 + stride_x
+    n6 = n4 + stride_y
+    n7 = n6 + stride_x
+
+    t1 = jnp.stack([n0, n1, n3, n7], axis=-1)
+    t2 = jnp.stack([n0, n1, n7, n5], axis=-1)
+    t3 = jnp.stack([n0, n5, n7, n4], axis=-1)
+    t4 = jnp.stack([n0, n3, n2, n7], axis=-1)
+    t5 = jnp.stack([n0, n2, n6, n7], axis=-1)
+    t6 = jnp.stack([n0, n6, n4, n7], axis=-1)
+
+    all_tets = jnp.stack([t1, t2, t3, t4, t5, t6], axis=1)
+    elements = all_tets.reshape(-1, 4)
+
+    return Mesh(coords=jnp.array(nodes), elements=jnp.array(elements))
+
+
+@pytest.fixture
+def line_operator():
+    """Factory fixture: build an Operator over a 1-D Line2 mesh embedded in 2-D.
+
+    ``Line2`` computes its Jacobian from a tangent vector ``[J[0], J[1]]``, so the
+    coordinates must live in 2-D; we lay the nodes along the x-axis with ``y = 0``.
+    """
+
+    def _make(n_nodes: int, length: float = 1.0) -> Operator:
+        x = jnp.linspace(0, length, n_nodes)
+        coords = jnp.stack([x, jnp.zeros(n_nodes)], axis=1)
+        elements = jnp.stack([jnp.arange(n_nodes - 1), jnp.arange(1, n_nodes)], axis=1)
+        return Operator(Mesh(coords=coords, elements=elements), element.Line2())
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# energy-functional tracing (d²E/du²)
+# ---------------------------------------------------------------------------
+
+
+def test_3d_vector_field_sparsity():
+    """3-D Neo-Hookean hyperelasticity with Dirichlet load: the traced Hessian sparsity
+    must contain every entry of the tatva-built (reduced) element sparsity pattern."""
+
+    class Material(NamedTuple):
+        mu: float
+        lmbda: float
+
+    @autovmap(grad_u=2)
+    def compute_deformation_gradient(grad_u):
+        I = jnp.eye(3)
+        F = I + grad_u
+        return F
+
+    @autovmap(grad_u=2, mu=0, lmbda=0)
+    def neo_hookean_density(grad_u, mu, lmbda):
+        F = compute_deformation_gradient(grad_u)
+        J = jnp.linalg.det(F)
+        C = F.T @ F
+        I1 = jnp.trace(C)
+        return (mu / 2) * (I1 - 3 - 2 * jnp.log(J)) + (lmbda / 2) * (jnp.log(J)) ** 2
+
+    L, W, H = 10.0, 1.0, 1.0
+    nx, ny, nz = 10, 2, 2
+    mesh = create_rectangle_box_tetrahedron_mesh((L, H, W), (nx, ny, nz))
+
+    class Solution(compound.Compound, mesh=mesh):
+        u = compound.field(shape=(FieldSize.AUTO, 3))
+
+    tet_elem = element.Tetrahedron4()
+    op = Operator(mesh, tet_elem)
+    mat = Material(mu=500.0, lmbda=1000.0)
+
+    x_min, x_max = jnp.min(mesh.coords[:, 0]), jnp.max(mesh.coords[:, 0])
+    fixed_nodes = jnp.where(jnp.isclose(mesh.coords[:, 0], x_min))[0]
+    load_nodes = jnp.where(jnp.isclose(mesh.coords[:, 0], x_max))[0]
+    applied_u_load = 1.0
+
+    lifter_ = lifter.Lifter(
+        Solution.size,
+        lifter.Fixed(Solution.u[fixed_nodes, :]),
+        lifter.Fixed(Solution.u[load_nodes, 2], values=applied_u_load),
+    )
+
+    @jax.jit
+    def total_energy(sol: Solution) -> Array:
+        (u,) = sol
+        grad_u = op.grad(u)
+        psi = neo_hookean_density(grad_u, mat.mu, mat.lmbda)
+        return op.integrate(psi)
+
+    @jax.jit
+    def total_energy_free(u_free: Array, lf: lifter.Lifter) -> Array:
+        sol = Solution(lf.lift_from_zeros(u_free))
+        return total_energy(sol)
+
+    sparsity_pattern = sparse.create_sparsity_pattern(mesh, n_dofs_per_node=3)
+    reduced_sparsity = sparse.reduce_sparsity_pattern(
+        sparsity_pattern, lifter_.free_dofs
+    )
+
+    traced_sparsity = trace_energy_sparsity(
+        total_energy_free, lifter_.size_reduced, lifter_
+    )
+
+    # The tracer must not miss any coupling present in the FEM element pattern.
+    assert nz_set(reduced_sparsity) <= nz_set(traced_sparsity)
+
+
+def test_periodic_constraint_sparsity():
+    """Periodic + Dirichlet constraints: the tracer applied to the lifted (reduced)
+    energy must reproduce tatva's own augment/reduce sparsity pipeline exactly."""
+
+    n_x, n_y = 4, 4
+    mesh = Mesh.unit_square(n_x, n_y)
+    op = Operator(mesh, element.Tri3())
+
+    # Define boundaries
+    y_min = np.min(mesh.coords[:, 1])
+    bot_nodes = np.where(mesh.coords[:, 1] == y_min)[0]
+
+    left_nodes = np.where(mesh.coords[:, 0] == 0.0)[0]
+    left_nodes = left_nodes[np.argsort(mesh.coords[left_nodes, 1])]
+    right_nodes = np.where(mesh.coords[:, 0] == 1.0)[0]
+    right_nodes = right_nodes[np.argsort(mesh.coords[right_nodes, 1])]
+
+    class Solution(compound.Compound, mesh=mesh):
+        u = compound.field((FieldSize.AUTO, 2))
+
+    my_lifter = lifter.Lifter(
+        Solution.size,
+        lifter.Fixed(Solution.u[bot_nodes, :], 0.0),
+        lifter.Periodic(Solution.u[left_nodes, :], Solution.u[right_nodes, :]),
+    )
+
+    sparsity_full = Solution.get_sparsity()
+    sparsity_augmented = my_lifter.augment_sparsity(sparsity_full)
+    pat_reduced_expected = my_lifter.reduce_sparsity(sparsity_augmented)
+
+    mu, lmbda = 1.0, 1.0
+
+    @autovmap(grad_u=2)
+    def neo_hookean_energy(grad_u):
+        F = jnp.eye(2) + grad_u
+        J = jnp.linalg.det(F)
+        C = F.T @ F
+        I1 = jnp.trace(C)
+        return (mu / 2) * (I1 - 2 - 2 * jnp.log(J)) + (lmbda / 2) * (jnp.log(J) ** 2)
+
+    def local_energy_fn(sol: Solution):
+        (u,) = sol
+        strain = op.integrate(neo_hookean_energy(op.grad(u)))
+        return strain
+
+    @jax.jit
+    def local_energy_free(u_free: Array, lf: lifter.Lifter) -> Array:
+        sol = Solution(lf.lift_from_zeros(u_free))
+        return local_energy_fn(sol)
+
+    pat_reduced_actual = trace_energy_sparsity(
+        local_energy_free, my_lifter.size_reduced, my_lifter
+    )
+
+    assert nz_set(pat_reduced_actual) == nz_set(pat_reduced_expected)
+
+
+def test_lagrangian_multiplier_sparsity():
+    """Mixed displacement / Lagrange-multiplier adhesion potential: the traced sparsity
+    must have no false negatives against the dense reference Hessian."""
+
+    Lx, Ly = 6.0, 2.0
+    Nx, Ny = 4, 3
+    x = np.linspace(0, Lx, Nx)
+    y = np.linspace(0, Ly, Ny)
+    xv, yv = np.meshgrid(x, y, indexing="ij")
+    coords = np.stack([xv.flatten(), yv.flatten()], axis=1)
+
+    elements = []
+    for i in range(Nx - 1):
+        for j in range(Ny - 1):
+            n0 = i * Ny + j
+            n1 = (i + 1) * Ny + j
+            n2 = i * Ny + (j + 1)
+            n3 = (i + 1) * Ny + (j + 1)
+            elements.append([n0, n1, n2])
+            elements.append([n1, n3, n2])
+    elements = np.array(elements)
+
+    mesh = Mesh(jnp.asarray(coords), jnp.asarray(elements))
+
+    # Identify horizontal line elements on the bottom boundary (y=0)
+    line_elements = []
+    for i in range(Nx - 1):
+        n0 = i * Ny
+        n1 = (i + 1) * Ny
+        line_elements.append([n0, n1])
+    line_elements = np.array(line_elements)
+
+    op = Operator(mesh, element.Tri3())
+    op_line = Operator(replace(mesh, elements=line_elements), element.Line2())
+
+    class Material(NamedTuple):
+        mu: float
+        lmbda: float
+
+    mat = Material(mu=0.5, lmbda=1.0)
+
+    class Solution(compound.Compound):
+        u_rigid = compound.field((3,))
+        u = compound.field((mesh.coords.shape))
+        lm = compound.field((op_line.mesh.elements.shape[0],))
+
+    @autovmap(grad_u=2)
+    def compute_deformation_gradient(grad_u: Array) -> Array:
+        return jnp.eye(2) + grad_u
+
+    @autovmap(grad_u=2, mat=None)
+    def strain_energy_density(grad_u: Array, mat: Material) -> Array:
+        F = compute_deformation_gradient(grad_u)
+        C = F.T @ F
+        J = jnp.linalg.det(F)
+        return (
+            mat.mu / 2.0 * (jnp.trace(C) - 2.0)
+            - mat.mu * jnp.log(J)
+            + (mat.lmbda / 2.0) * (jnp.log(J)) ** 2
+        )
+
+    def equality_constraint_potential(lm, u, active_set):
+        density = jnp.where(
+            active_set[..., None],
+            lm[..., None] * op_line.eval(u)[..., 1],
+            0.5 * lm[..., None] ** 2,
+        )
+        return op_line.integrate(density)
+
+    @jax.jit
+    def total_lagrangian(z, active_set, mat):
+        u_rigid, u, lm = Solution(z)
+        psi = strain_energy_density(op.grad(u), mat)
+        Psi = op.integrate(psi)
+        G = equality_constraint_potential(lm, u, active_set)
+        return Psi + G
+
+    # Seed all active constraints
+    u_rigid_dummy, u_dummy, lm_dummy = Solution()
+    active_set = jnp.ones_like(lm_dummy, dtype=bool)
+
+    energy_fn = lambda z: total_lagrangian(z, active_set, mat)
+
+    # Initialize a small non-zero state to ensure valid Jacobian/Hessian evaluation (det(F) > 0)
+    z_dummy = np.random.uniform(-0.02, 0.02, size=Solution.size)
+    u_rigid_val, u_val, lm_val = Solution(jnp.array(z_dummy))
+    # Ensure u has small perturbations on top of zero to avoid zero determinant or inversion errors
+    z_dummy = Solution(u_rigid=u_rigid_val, u=u_val, lm=lm_val).flatten()
+
+    h_dense = jax.hessian(energy_fn)(z_dummy)
+    ref_sparsity = np.abs(h_dense) > 1e-12
+
+    pat_traced = trace_energy_sparsity(energy_fn, n_dofs=Solution.size)
+    traced_sparsity = pat_traced.toarray() > 0
+
+    fn_mask = ref_sparsity & (~traced_sparsity)
+    fn_count = np.sum(fn_mask)
+
+    # Building a colored matrix from the traced pattern must succeed (smoke check).
+    colored_matrix = sparse.ColoredMatrix.from_csr(pat_traced)
+    assert np.max(colored_matrix.colors) + 1 >= 1
+
+    assert fn_count == 0, (
+        "Validation failed: False negatives detected in Adhesion Lagrange Multipliers!"
+    )
+
+
+# ---------------------------------------------------------------------------
+# virtual-work tracing (tangent stiffness K = dR/du = d²G/dv du)
+# ---------------------------------------------------------------------------
+
+
+def _virtual_work_reference(vw, n_dofs: int, u_dummy: Array) -> sps.csr_matrix:
+    """Dense reference tangent-stiffness pattern: K_ij = d/du_j ( dG/dw_i )."""
+
+    def R_fn(u_flat: Array) -> Array:
+        return jax.grad(vw, argnums=0)(jnp.zeros(n_dofs), u_flat)
+
+    K_exact = jax.jacobian(R_fn)(u_dummy)
+    return sps.csr_matrix(np.abs(np.asarray(K_exact)) > 1e-12, dtype=np.int8)
+
+
+def _assert_traced_matches(pat, K_pat, lf: lifter.Lifter, exact: bool = True) -> None:
+    """Validate the traced sparsity against the reference, both full and lifter-reduced.
+
+    The tracer guarantees no false negatives (traced ⊇ reference). For forms where it is
+    also tight (no spurious couplings) we assert exact equality; for conservative cases
+    (e.g. purely bilinear saddle-point forms) we only require the superset property.
+    """
+    free = np.asarray(lf.free_dofs)
+    K_reduced = sps.csr_matrix(K_pat.toarray()[np.ix_(free, free)])
+    if exact:
+        assert nz_set(pat) == nz_set(K_pat)
+        assert nz_set(lf.reduce_sparsity(pat)) == nz_set(K_reduced)
+    else:
+        # no false negatives: every reference coupling must be captured
+        assert nz_set(K_pat) <= nz_set(pat)
+        assert nz_set(K_reduced) <= nz_set(lf.reduce_sparsity(pat))
+
+
+def test_advection_diffusion_virtual_work_sparsity(line_operator):
+    """Advection-Diffusion (non-symmetric coupling) discretized on a 1-D Line2 mesh."""
+    N = 8
+    D = 1.0  # Diffusion coeff
+    V = 1.5  # Advection velocity
+    op = line_operator(N)
+
+    class Field(compound.Compound, mesh=op.mesh):
+        u = compound.field((FieldSize.AUTO, 1))
+
+    @jax.jit
+    def g_fn(w, u):
+        (u_n,) = Field(u)
+        (w_n,) = Field(w)
+        du = op.grad(u_n)
+        dw = op.grad(w_n)
+        w_q = op.eval(w_n)
+        return op.integrate(D * du * dw + V * du * w_q).sum()
+
+    my_lifter = lifter.Lifter(Field.size, lifter.Fixed(Field.u[jnp.array([0]), :]))
+
+    pat = trace_virtual_work_sparsity(g_fn, Field.size, trial_arg="u", test_arg="w")
+    u_dummy = jnp.arange(Field.size, dtype=jnp.float64)
+    K_pat = _virtual_work_reference(g_fn, Field.size, u_dummy)
+
+    _assert_traced_matches(pat, K_pat, my_lifter)
+
+
+def test_nonlinear_coupling_virtual_work_sparsity(line_operator):
+    """Nonlinear reaction-diffusion virtual work (nonlinear coupling via w * u**3)."""
+    N = 6
+    op = line_operator(N)
+
+    class Field(compound.Compound, mesh=op.mesh):
+        u = compound.field((FieldSize.AUTO, 1))
+
+    @jax.jit
+    def g_fn(w, u):
+        (u_n,) = Field(u)
+        (w_n,) = Field(w)
+        du = op.grad(u_n)
+        dw = op.grad(w_n)
+        u_q = op.eval(u_n)
+        w_q = op.eval(w_n)
+        return op.integrate(du * dw + w_q * u_q**3).sum()
+
+    my_lifter = lifter.Lifter(Field.size, lifter.Fixed(Field.u[jnp.array([0]), :]))
+
+    pat = trace_virtual_work_sparsity(g_fn, Field.size, trial_arg="u", test_arg="w")
+    # Avoid the trivial derivative of u**3 at zero.
+    u_dummy = jnp.arange(N, dtype=jnp.float64) + 1.0
+    K_pat = _virtual_work_reference(g_fn, Field.size, u_dummy)
+
+    _assert_traced_matches(pat, K_pat, my_lifter)
+
+
+def test_mixed_nodal_virtual_work_sparsity(line_operator):
+    """Mixed velocity-pressure saddle-point virtual work (block structure via Compound)."""
+    N = 5
+    op = line_operator(N)
+
+    class Mixed(compound.Compound, mesh=op.mesh):
+        v = compound.field((FieldSize.AUTO, 1))
+        p = compound.field((FieldSize.AUTO, 1))
+
+    @jax.jit
+    def g_fn(test, trial):
+        v, p = Mixed(trial)
+        w, q = Mixed(test)
+        dv = op.grad(v)
+        dw = op.grad(w)
+        p_q = op.eval(p)
+        q_q = op.eval(q)
+        elastic = op.integrate(dw * dv).sum()
+        coupling1 = op.integrate(dw * p_q).sum()
+        coupling2 = op.integrate(q_q * dv).sum()
+        return elastic + coupling1 + coupling2
+
+    my_lifter = lifter.Lifter(Mixed.size, lifter.Fixed(Mixed.v[jnp.array([0]), :]))
+
+    pat = trace_virtual_work_sparsity(
+        g_fn, Mixed.size, trial_arg="trial", test_arg="test"
+    )
+    u_dummy = jnp.arange(Mixed.size, dtype=jnp.float64)
+    K_pat = _virtual_work_reference(g_fn, Mixed.size, u_dummy)
+
+    # The mixed bilinear form is traced conservatively (extra within-node v-p partner
+    # couplings), so we require the no-false-negative guarantee rather than exact equality.
+    _assert_traced_matches(pat, K_pat, my_lifter, exact=False)
+
+
+def test_unsymmetric_sparsity(line_operator):
+    """Two-field one-way coupling (a's residual sees b, but b's never sees a), the
+    hallmark of a non-associated tangent: the traced pattern must be genuinely
+    unsymmetric and contain every coupling of the unsymmetric reference Jacobian."""
+    N = 6
+    op = line_operator(N)
+
+    class TwoField(compound.Compound, mesh=op.mesh):
+        a = compound.field((FieldSize.AUTO, 1))
+        b = compound.field((FieldSize.AUTO, 1))
+
+    @jax.jit
+    def g_fn(test, trial):
+        a, b = TwoField(trial)
+        wa, wb = TwoField(test)
+        diffusion = op.integrate(op.grad(wa) * op.grad(a)).sum()
+        diffusion += op.integrate(op.grad(wb) * op.grad(b)).sum()
+        one_way = op.integrate(op.eval(wa) * op.grad(b)).sum()  # a-residual depends on b
+        return diffusion + one_way
+
+    my_lifter = lifter.Lifter(TwoField.size, lifter.Fixed(TwoField.a[jnp.array([0]), :]))
+
+    pat = trace_virtual_work_sparsity(
+        g_fn, TwoField.size, trial_arg="trial", test_arg="test"
+    )
+    u_dummy = jnp.arange(TwoField.size, dtype=jnp.float64)
+    K_pat = _virtual_work_reference(g_fn, TwoField.size, u_dummy)
+
+    # The one-way coupling must yield a genuinely unsymmetric pattern (otherwise the test
+    # would not exercise the non-symmetric tangent path of the virtual-work tracer).
+    assert nz_set(K_pat) != nz_set(K_pat.T)
+    assert nz_set(pat) != nz_set(pat.T)
+
+    # Two interleaved nodal fields are traced conservatively, so require no false negatives.
+    _assert_traced_matches(pat, K_pat, my_lifter, exact=False)

--- a/tests/test_sparse_tracer.py
+++ b/tests/test_sparse_tracer.py
@@ -11,7 +11,11 @@ from jax_autovmap import autovmap
 
 from tatva import Mesh, Operator, compound, element, lifter, sparse
 from tatva.compound import FieldSize
-from tatva.sparse import trace_energy_sparsity, trace_virtual_work_sparsity
+from tatva.sparse import (
+    pattern_from_compound,
+    pattern_from_energy,
+    pattern_from_virtual_work,
+)
 
 jax.config.update("jax_enable_x64", True)
 
@@ -144,12 +148,10 @@ def test_3d_vector_field_sparsity():
         sol = Solution(lf.lift_from_zeros(u_free))
         return total_energy(sol)
 
-    sparsity_pattern = sparse.create_sparsity_pattern(mesh, n_dofs_per_node=3)
-    reduced_sparsity = sparse.reduce_sparsity_pattern(
-        sparsity_pattern, lifter_.free_dofs
-    )
+    sparsity_pattern = sparse.pattern_from_mesh(mesh, n_dofs_per_node=3)
+    reduced_sparsity = lifter_.adapt_sparsity(sparsity_pattern)
 
-    traced_sparsity = trace_energy_sparsity(
+    traced_sparsity = pattern_from_energy(
         total_energy_free, lifter_.size_reduced, lifter_
     )
 
@@ -183,7 +185,7 @@ def test_periodic_constraint_sparsity():
         lifter.Periodic(Solution.u[left_nodes, :], Solution.u[right_nodes, :]),
     )
 
-    sparsity_full = Solution.get_sparsity()
+    sparsity_full = pattern_from_compound(Solution)
     sparsity_augmented = my_lifter.augment_sparsity(sparsity_full)
     pat_reduced_expected = my_lifter.reduce_sparsity(sparsity_augmented)
 
@@ -207,7 +209,7 @@ def test_periodic_constraint_sparsity():
         sol = Solution(lf.lift_from_zeros(u_free))
         return local_energy_fn(sol)
 
-    pat_reduced_actual = trace_energy_sparsity(
+    pat_reduced_actual = pattern_from_energy(
         local_energy_free, my_lifter.size_reduced, my_lifter
     )
 
@@ -306,7 +308,7 @@ def test_lagrangian_multiplier_sparsity():
     h_dense = jax.hessian(energy_fn)(z_dummy)
     ref_sparsity = np.abs(h_dense) > 1e-12
 
-    pat_traced = trace_energy_sparsity(energy_fn, n_dofs=Solution.size)
+    pat_traced = pattern_from_energy(energy_fn, n_dofs=Solution.size)
     traced_sparsity = pat_traced.toarray() > 0
 
     fn_mask = ref_sparsity & (~traced_sparsity)
@@ -375,7 +377,7 @@ def test_advection_diffusion_virtual_work_sparsity(line_operator):
 
     my_lifter = lifter.Lifter(Field.size, lifter.Fixed(Field.u[jnp.array([0]), :]))
 
-    pat = trace_virtual_work_sparsity(g_fn, Field.size, trial_arg="u", test_arg="w")
+    pat = pattern_from_virtual_work(g_fn, Field.size, trial_arg="u", test_arg="w")
     u_dummy = jnp.arange(Field.size, dtype=jnp.float64)
     K_pat = _virtual_work_reference(g_fn, Field.size, u_dummy)
 
@@ -402,7 +404,7 @@ def test_nonlinear_coupling_virtual_work_sparsity(line_operator):
 
     my_lifter = lifter.Lifter(Field.size, lifter.Fixed(Field.u[jnp.array([0]), :]))
 
-    pat = trace_virtual_work_sparsity(g_fn, Field.size, trial_arg="u", test_arg="w")
+    pat = pattern_from_virtual_work(g_fn, Field.size, trial_arg="u", test_arg="w")
     # Avoid the trivial derivative of u**3 at zero.
     u_dummy = jnp.arange(N, dtype=jnp.float64) + 1.0
     K_pat = _virtual_work_reference(g_fn, Field.size, u_dummy)
@@ -434,7 +436,7 @@ def test_mixed_nodal_virtual_work_sparsity(line_operator):
 
     my_lifter = lifter.Lifter(Mixed.size, lifter.Fixed(Mixed.v[jnp.array([0]), :]))
 
-    pat = trace_virtual_work_sparsity(
+    pat = pattern_from_virtual_work(
         g_fn, Mixed.size, trial_arg="trial", test_arg="test"
     )
     u_dummy = jnp.arange(Mixed.size, dtype=jnp.float64)
@@ -462,12 +464,16 @@ def test_unsymmetric_sparsity(line_operator):
         wa, wb = TwoField(test)
         diffusion = op.integrate(op.grad(wa) * op.grad(a)).sum()
         diffusion += op.integrate(op.grad(wb) * op.grad(b)).sum()
-        one_way = op.integrate(op.eval(wa) * op.grad(b)).sum()  # a-residual depends on b
+        one_way = op.integrate(
+            op.eval(wa) * op.grad(b)
+        ).sum()  # a-residual depends on b
         return diffusion + one_way
 
-    my_lifter = lifter.Lifter(TwoField.size, lifter.Fixed(TwoField.a[jnp.array([0]), :]))
+    my_lifter = lifter.Lifter(
+        TwoField.size, lifter.Fixed(TwoField.a[jnp.array([0]), :])
+    )
 
-    pat = trace_virtual_work_sparsity(
+    pat = pattern_from_virtual_work(
         g_fn, TwoField.size, trial_arg="trial", test_arg="test"
     )
     u_dummy = jnp.arange(TwoField.size, dtype=jnp.float64)

--- a/tests/test_sparse_tracer.py
+++ b/tests/test_sparse_tracer.py
@@ -323,6 +323,46 @@ def test_lagrangian_multiplier_sparsity():
     )
 
 
+def test_remat_checkpoint_sparsity():
+    """Couplings created inside a ``jax.checkpoint`` block must be traced.
+
+    ``jax.checkpoint`` emits a ``remat2`` primitive carrying a (bare) sub-jaxpr. The
+    tracer must descend into it; treating it as an opaque fallback would silently drop
+    the second-order couplings produced inside and under-count the Hessian.
+    """
+    M = 8
+
+    @jax.checkpoint
+    def coupled_block(eps):
+        # genuine nonlinear coupling-producing block, wrapped in remat
+        return 0.5 * eps**2 + 0.25 * eps**4
+
+    def macro_energy(U):
+        energy = 0.0
+        for i in range(M - 1):
+            energy += coupled_block(U[i] - U[i + 1])
+        return energy
+
+    U_dummy = np.random.randn(M)
+
+    # Guard: the test is only meaningful if remat2 actually survives in the jaxpr.
+    prims = {e.primitive.name for e in jax.make_jaxpr(macro_energy)(U_dummy).jaxpr.eqns}
+    assert "remat2" in prims, "expected jax.checkpoint to emit a remat2 primitive"
+
+    h_dense = jax.hessian(macro_energy)(U_dummy)
+    ref_sparsity = np.abs(h_dense) > 1e-12
+
+    pat_traced = pattern_from_energy(macro_energy, n_dofs=M)
+    traced_sparsity = pat_traced.toarray() > 0
+
+    # No false negatives: every true coupling must be present in the traced pattern.
+    fn_count = np.sum(ref_sparsity & (~traced_sparsity))
+    assert fn_count == 0, "remat2 couplings were dropped by the tracer"
+
+    # Coupling structure is exactly tridiagonal (eps_i = U[i] - U[i+1]).
+    assert pat_traced.nnz == int(np.sum(ref_sparsity)) == 3 * M - 2
+
+
 # ---------------------------------------------------------------------------
 # virtual-work tracing (tangent stiffness K = dR/du = d²G/dv du)
 # ---------------------------------------------------------------------------

--- a/tests/test_sparse_tracer_core.py
+++ b/tests/test_sparse_tracer_core.py
@@ -23,7 +23,7 @@ import numpy as np
 import pytest
 import scipy.sparse as sps
 
-from tatva.sparse import trace_energy_sparsity, trace_virtual_work_sparsity
+from tatva.sparse import pattern_from_energy, pattern_from_virtual_work
 from tatva.sparse.tracer import (
     CouplingAccumulator,
     SparseDepSet,
@@ -120,7 +120,12 @@ ENERGY_CASES = [
         6,
         True,
     ),
-    ("concatenate_duplicate", lambda u: jnp.sum(jnp.sin(jnp.concatenate([u, u]))), 6, True),
+    (
+        "concatenate_duplicate",
+        lambda u: jnp.sum(jnp.sin(jnp.concatenate([u, u]))),
+        6,
+        True,
+    ),
     ("squeeze", lambda u: jnp.sum(jnp.sin(u[:, None]).squeeze(-1)), 6, True),
     ("slice_product", lambda u: jnp.sum(u[:3] * u[3:]), 6, False),
     # --- gather / scatter ---
@@ -164,14 +169,14 @@ _ENERGY_IDS = [c[0] for c in ENERGY_CASES]
 @pytest.mark.parametrize("fn,n,exact", [c[1:] for c in ENERGY_CASES], ids=_ENERGY_IDS)
 def test_energy_no_false_negatives(fn, n, exact):
     """The traced Hessian pattern must contain every entry of the true pattern."""
-    pat = trace_energy_sparsity(fn, n)
+    pat = pattern_from_energy(fn, n)
     assert dense_hessian_pattern(fn, n) <= nz_set(pat)
 
 
 @pytest.mark.parametrize("fn,n,exact", [c[1:] for c in ENERGY_CASES], ids=_ENERGY_IDS)
 def test_energy_hessian_structurally_symmetric(fn, n, exact):
     """An energy Hessian pattern is symmetric: the tracer records both (i,j) and (j,i)."""
-    pat = trace_energy_sparsity(fn, n)
+    pat = pattern_from_energy(fn, n)
     assert nz_set(pat) == nz_set(pat.T)
 
 
@@ -182,7 +187,7 @@ def test_energy_hessian_structurally_symmetric(fn, n, exact):
 )
 def test_energy_exact_pattern(fn, n):
     """For tight cases the traced pattern equals the true structural pattern exactly."""
-    pat = trace_energy_sparsity(fn, n)
+    pat = pattern_from_energy(fn, n)
     assert nz_set(pat) == dense_hessian_pattern(fn, n)
 
 
@@ -204,7 +209,7 @@ def test_energy_exact_pattern(fn, n):
 def test_zero_hessian_returns_identity(fn):
     """When nothing couples, ``_trace_hessian_sparsity`` falls back to the identity."""
     n = 4
-    pat = trace_energy_sparsity(fn, n)
+    pat = pattern_from_energy(fn, n)
     assert nz_set(pat) == nz_set(sps.eye(n))
 
 
@@ -221,7 +226,7 @@ def test_integer_pow_exponent_classification(exponent, records):
     """``integer_pow`` only records couplings for exponents >= 2 or <= -1."""
     # the +2.0 offset keeps the base away from 0 so the reciprocal (y=-1) is well defined
     fn = lambda u: jnp.sum((u + 2.0) ** exponent)
-    pat = trace_energy_sparsity(fn, 4)
+    pat = pattern_from_energy(fn, 4)
     if records:
         # y in {-1, 2, 3}: genuine diagonal curvature is recorded
         assert nz_set(pat) == {(i, i) for i in range(4)}
@@ -242,20 +247,20 @@ def test_integer_pow_exponent_classification(exponent, records):
 )
 def test_linear_scaling_not_recorded(fn):
     """``mul``/``div`` by a constant is linear and must record no couplings."""
-    pat = trace_energy_sparsity(fn, 5)
+    pat = pattern_from_energy(fn, 5)
     assert nz_set(pat) == nz_set(sps.eye(5))
 
 
 def test_unary_nonlinear_is_separable_diagonal():
     """An element-wise unary nonlinearity yields a purely diagonal Hessian pattern."""
-    pat = trace_energy_sparsity(lambda u: jnp.sum(jnp.sin(u)), 5)
+    pat = pattern_from_energy(lambda u: jnp.sum(jnp.sin(u)), 5)
     assert nz_set(pat) == {(i, i) for i in range(5)}
 
 
 def test_binary_product_couples_operands():
     """``u[:-1] * u[1:]`` couples adjacent DOFs (a superset of the off-diagonal pattern)."""
     n = 5
-    pat = trace_energy_sparsity(lambda u: jnp.sum(u[:-1] * u[1:]), n)
+    pat = pattern_from_energy(lambda u: jnp.sum(u[:-1] * u[1:]), n)
     # every true adjacency must be captured
     expected_adjacent = {(i, i + 1) for i in range(n - 1)} | {
         (i + 1, i) for i in range(n - 1)
@@ -271,9 +276,9 @@ def test_binary_product_couples_operands():
 def test_nested_jit_matches_unjitted():
     """``@jax.jit`` (and nesting) must not change the traced pattern."""
     e = lambda u: jnp.sum(u[:-1] * u[1:]) + jnp.sum(jnp.sin(u))
-    base = nz_set(trace_energy_sparsity(e, 6))
-    assert nz_set(trace_energy_sparsity(jax.jit(e), 6)) == base
-    assert nz_set(trace_energy_sparsity(jax.jit(jax.jit(e)), 6)) == base
+    base = nz_set(pattern_from_energy(e, 6))
+    assert nz_set(pattern_from_energy(jax.jit(e), 6)) == base
+    assert nz_set(pattern_from_energy(jax.jit(jax.jit(e)), 6)) == base
 
 
 def test_cond_internal_nonlinearity_captured():
@@ -286,7 +291,7 @@ def test_cond_internal_nonlinearity_captured():
         lambda v: jnp.sum(v**2),  # diagonal
         u,
     )
-    pat = trace_energy_sparsity(fn, n)
+    pat = pattern_from_energy(fn, n)
     assert dense_hessian_pattern(fn, n) <= nz_set(pat)
     # union of a tridiagonal and a diagonal branch is exactly the tridiagonal pattern
     assert nz_set(pat) == dense_hessian_pattern(fn, n)
@@ -298,7 +303,7 @@ def test_cond_nonlinearity_after_branch_is_sound():
     fn = lambda u: jnp.sum(
         jax.lax.cond(u[0] > 0, lambda v: v * 2.0, lambda v: v[::-1] * 3.0, u) ** 2
     )
-    assert dense_hessian_pattern(fn, n) <= nz_set(trace_energy_sparsity(fn, n))
+    assert dense_hessian_pattern(fn, n) <= nz_set(pattern_from_energy(fn, n))
 
 
 def test_switch_multibranch_captured():
@@ -313,7 +318,7 @@ def test_switch_multibranch_captured():
         ],
         u,
     )
-    assert dense_hessian_pattern(fn, n) <= nz_set(trace_energy_sparsity(fn, n))
+    assert dense_hessian_pattern(fn, n) <= nz_set(pattern_from_energy(fn, n))
 
 
 @pytest.mark.xfail(
@@ -325,7 +330,7 @@ def test_scan_carry_coupling_is_unsound():
     """Documents a soundness boundary: cross-iteration coupling via a scan carry."""
     n = 6
     fn = lambda u: jnp.sum(jax.lax.scan(lambda c, x: (x, c * x), 1.0, u)[1])
-    assert dense_hessian_pattern(fn, n) <= nz_set(trace_energy_sparsity(fn, n))
+    assert dense_hessian_pattern(fn, n) <= nz_set(pattern_from_energy(fn, n))
 
 
 # ---------------------------------------------------------------------------
@@ -337,9 +342,9 @@ def test_virtual_work_bad_argument_name_raises():
     """An unknown ``trial_arg`` / ``test_arg`` name is rejected up front."""
     g = lambda w, u: jnp.sum(w * u)
     with pytest.raises(ValueError, match="Trial argument 'x' not found"):
-        trace_virtual_work_sparsity(g, 3, trial_arg="x", test_arg="w")
+        pattern_from_virtual_work(g, 3, trial_arg="x", test_arg="w")
     with pytest.raises(ValueError, match="Test argument 'y' not found"):
-        trace_virtual_work_sparsity(g, 3, trial_arg="u", test_arg="y")
+        pattern_from_virtual_work(g, 3, trial_arg="u", test_arg="y")
 
 
 def test_virtual_work_excludes_trial_only_term():
@@ -347,7 +352,7 @@ def test_virtual_work_excludes_trial_only_term():
     n = 4
     # cross term w*u (→ diagonal K) plus a trial-only nonlinearity u**2 that must be masked
     g = lambda w, u: jnp.sum(w * u) + jnp.sum(u**2)
-    K = trace_virtual_work_sparsity(g, n, trial_arg="u", test_arg="w")
+    K = pattern_from_virtual_work(g, n, trial_arg="u", test_arg="w")
     assert nz_set(K) == {(i, i) for i in range(n)}
 
 
@@ -355,7 +360,7 @@ def test_virtual_work_static_arg_forwarded():
     """Extra ``*static_args`` are forwarded positionally to the virtual-work function."""
     n = 4
     g = lambda w, u, kappa: jnp.sum(kappa * w[:-1] * u[1:])
-    K = trace_virtual_work_sparsity(g, n, "u", "w", 2.0)
+    K = pattern_from_virtual_work(g, n, "u", "w", 2.0)
     assert dense_vw_pattern(lambda w, u: g(w, u, 2.0), n) <= nz_set(K)
     assert K.nnz > 0  # the static coefficient does not zero-out the coupling
 
@@ -364,7 +369,7 @@ def test_virtual_work_default_arg_used():
     """A parameter with a default is filled from the signature when not supplied."""
     n = 4
     g = lambda w, u, kappa=3.0: jnp.sum(kappa * w[:-1] * u[1:])
-    K = trace_virtual_work_sparsity(g, n, "u", "w")
+    K = pattern_from_virtual_work(g, n, "u", "w")
     assert dense_vw_pattern(lambda w, u: g(w, u), n) <= nz_set(K)
 
 
@@ -373,7 +378,7 @@ def test_virtual_work_missing_static_arg_raises():
     n = 3
     g = lambda w, u, kappa: jnp.sum(kappa * w * u)
     with pytest.raises(ValueError, match="Missing static argument"):
-        trace_virtual_work_sparsity(g, n, "u", "w")
+        pattern_from_virtual_work(g, n, "u", "w")
 
 
 def test_virtual_work_unsymmetric_pattern_captured():
@@ -382,7 +387,7 @@ def test_virtual_work_unsymmetric_pattern_captured():
     n = 4
     # w_i couples to u_{i+1} but not the reverse → strictly upper off-diagonal block
     g = lambda w, u: jnp.sum(w[:-1] * u[1:])
-    K = trace_virtual_work_sparsity(g, n, trial_arg="u", test_arg="w")
+    K = pattern_from_virtual_work(g, n, trial_arg="u", test_arg="w")
     ref = dense_vw_pattern(g, n)
     assert ref <= nz_set(K)
     assert nz_set(K) != {(c, r) for (r, c) in nz_set(K)}  # not symmetric

--- a/tests/test_sparse_tracer_core.py
+++ b/tests/test_sparse_tracer_core.py
@@ -1,0 +1,468 @@
+"""Implementation-level tests for ``tatva.sparse.tracer``.
+
+These tests target the tracer's internal machinery directly — the primitive handlers in
+``Handlers``, the nonlinear classification, the JAXpr traversal, the higher-order handlers
+(``scan``/``map``/``cond``/``pjit``), the trial/test split logic and the small data
+structures — using tiny hand-written functions whose exact Hessian / Jacobian pattern is
+knowable via ``jax.hessian`` / ``jax.jacobian``. This complements ``test_sparse_tracer.py``,
+which exercises the tracer end-to-end through the FEM stack (Operator/Compound/Lifter).
+
+The core contract under test:
+  * **no false negatives** — the traced pattern is always a superset of the true pattern
+    (the property that makes it safe for graph-coloring based sparse AD), and
+  * **structural symmetry** — an energy Hessian pattern is always symmetric.
+
+``cond``/``switch`` branches are traversed (couplings created inside a branch are
+captured). One genuine soundness boundary remains documented as ``xfail``:
+  * a data-dependent *carry* coupling in ``lax.scan``.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import scipy.sparse as sps
+
+from tatva.sparse import trace_energy_sparsity, trace_virtual_work_sparsity
+from tatva.sparse.tracer import (
+    CouplingAccumulator,
+    SparseDepSet,
+    _unwrap_jit,
+)
+
+jax.config.update("jax_enable_x64", True)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def nz_set(m) -> set[tuple[int, int]]:
+    """CSR/array → set of ``(row, col)`` nonzero index tuples."""
+    m = sps.csr_matrix(m)
+    r, c = m.nonzero()
+    return set(zip(r.tolist(), c.tolist()))
+
+
+def dense_hessian_pattern(f, n: int, n_samples: int = 6, seed: int = 0) -> set:
+    """True structural Hessian pattern, unioned over several random evaluation points.
+
+    Unioning over points recovers the point-independent structural pattern while avoiding
+    accidental zeros at any single point. The union is always a subset of the structural
+    pattern, so ``dense ⊆ traced`` is the faithful no-false-negative check.
+    """
+    rng = np.random.default_rng(seed)
+    pattern: set = set()
+    for _ in range(n_samples):
+        x = jnp.asarray(rng.normal(size=n))
+        H = np.asarray(jax.hessian(f)(x))
+        rows, cols = np.where(np.abs(H) > 1e-9)
+        pattern |= set(zip(rows.tolist(), cols.tolist()))
+    return pattern
+
+
+def dense_vw_pattern(g, n: int, n_samples: int = 6, seed: int = 0) -> set:
+    """True tangent-stiffness pattern K_ij = d/du_j (dG/dw_i), unioned over points."""
+
+    def R_fn(u):
+        return jax.grad(g, argnums=0)(jnp.zeros(n), u)
+
+    rng = np.random.default_rng(seed)
+    pattern: set = set()
+    for _ in range(n_samples):
+        x = jnp.asarray(rng.normal(size=n))
+        K = np.asarray(jax.jacobian(R_fn)(x))
+        rows, cols = np.where(np.abs(K) > 1e-9)
+        pattern |= set(zip(rows.tolist(), cols.tolist()))
+    return pattern
+
+
+# ---------------------------------------------------------------------------
+# A. property battery: one minimal energy per handler family
+# ---------------------------------------------------------------------------
+
+_A = np.random.default_rng(1).normal(size=(6, 6))
+_A = jnp.asarray(_A + _A.T)  # symmetric → dense quadratic form
+_PERM = jnp.array([2, 0, 1, 1, 3, 5])
+_LO = jnp.array([0, 1, 2])
+_HI = jnp.array([3, 4, 5])
+_SCATTER_IDX = jnp.array([0, 1, 2, 0, 1, 2])
+
+
+# each case: (id, fn, n_dofs, exact) where ``exact`` asserts the traced pattern equals
+# the true structural pattern (otherwise only the no-false-negative superset is required)
+ENERGY_CASES = [
+    # --- scalar nonlinear handlers ---
+    ("unary_sin_diagonal", lambda u: jnp.sum(jnp.sin(u)), 6, True),
+    ("unary_dense_via_reduce", lambda u: jnp.sin(jnp.sum(u)), 6, True),
+    ("unary_exp", lambda u: jnp.sum(jnp.exp(u)), 6, True),
+    ("unary_log_safe", lambda u: jnp.sum(jnp.log(u**2 + 1.0)), 6, False),
+    ("unary_tanh", lambda u: jnp.sum(jnp.tanh(u)), 6, True),
+    ("binary_mul_adjacent", lambda u: jnp.sum(u[:-1] * u[1:]), 6, False),
+    ("binary_div_adjacent", lambda u: jnp.sum(u[:-1] / (u[1:] ** 2 + 1.0)), 6, False),
+    ("integer_pow2_diagonal", lambda u: jnp.sum(u**2), 6, True),
+    ("integer_pow3_diagonal", lambda u: jnp.sum(u**3), 6, True),
+    # --- contraction / reduction ---
+    ("dot_general_quadratic_form", lambda u: u @ _A @ u, 6, True),
+    ("reduce_sum_then_square", lambda u: jnp.sum(u.reshape(2, 3).sum(0) ** 2), 6, True),
+    # --- index-routing structural handlers ---
+    (
+        "reshape_transpose",
+        lambda u: jnp.sum(jnp.sin(u.reshape(2, 3).T.reshape(-1))),
+        6,
+        True,
+    ),
+    ("pad", lambda u: jnp.sum(jnp.sin(jnp.pad(u, (1, 1)))), 6, True),
+    (
+        "broadcast_in_dim",
+        lambda u: jnp.sum(jnp.sin(jnp.broadcast_to(u[:, None], (6, 3)))),
+        6,
+        True,
+    ),
+    ("concatenate_duplicate", lambda u: jnp.sum(jnp.sin(jnp.concatenate([u, u]))), 6, True),
+    ("squeeze", lambda u: jnp.sum(jnp.sin(u[:, None]).squeeze(-1)), 6, True),
+    ("slice_product", lambda u: jnp.sum(u[:3] * u[3:]), 6, False),
+    # --- gather / scatter ---
+    ("gather_permutation", lambda u: jnp.sum(jnp.sin(u[_PERM])), 6, True),
+    ("gather_product", lambda u: jnp.sum(u[_LO] * u[_HI]), 6, False),
+    (
+        "scatter_add_then_square",
+        lambda u: jnp.sum(jnp.zeros(3).at[_SCATTER_IDX].add(u) ** 2),
+        6,
+        True,
+    ),
+    # --- select / where ---
+    ("where_two_branches", lambda u: jnp.sum(jnp.where(u > 0, u**2, u**3)), 6, True),
+    # --- conservative fallbacks (no false negatives, not exact) ---
+    (
+        "dynamic_slice_fallback",
+        lambda u: jnp.sum(jax.lax.dynamic_slice(u, (1,), (3,)) ** 2),
+        6,
+        False,
+    ),
+    # --- higher-order: jit / map / scan(map-like) ---
+    ("nested_jit", jax.jit(lambda u: jnp.sum(u[:-1] * u[1:])), 6, False),
+    ("lax_map_independent", lambda u: jnp.sum(jax.lax.map(lambda x: x**2, u)), 6, True),
+    (
+        "lax_map_batched",
+        lambda u: jnp.sum(jax.lax.map(lambda x: x**2, u, batch_size=2)),
+        6,
+        True,
+    ),
+    (
+        "scan_map_like",
+        lambda u: jnp.sum(jax.lax.scan(lambda c, x: (c, x**2), 0.0, u)[1]),
+        6,
+        True,
+    ),
+]
+
+_ENERGY_IDS = [c[0] for c in ENERGY_CASES]
+
+
+@pytest.mark.parametrize("fn,n,exact", [c[1:] for c in ENERGY_CASES], ids=_ENERGY_IDS)
+def test_energy_no_false_negatives(fn, n, exact):
+    """The traced Hessian pattern must contain every entry of the true pattern."""
+    pat = trace_energy_sparsity(fn, n)
+    assert dense_hessian_pattern(fn, n) <= nz_set(pat)
+
+
+@pytest.mark.parametrize("fn,n,exact", [c[1:] for c in ENERGY_CASES], ids=_ENERGY_IDS)
+def test_energy_hessian_structurally_symmetric(fn, n, exact):
+    """An energy Hessian pattern is symmetric: the tracer records both (i,j) and (j,i)."""
+    pat = trace_energy_sparsity(fn, n)
+    assert nz_set(pat) == nz_set(pat.T)
+
+
+@pytest.mark.parametrize(
+    "fn,n",
+    [c[1:3] for c in ENERGY_CASES if c[3]],
+    ids=[c[0] for c in ENERGY_CASES if c[3]],
+)
+def test_energy_exact_pattern(fn, n):
+    """For tight cases the traced pattern equals the true structural pattern exactly."""
+    pat = trace_energy_sparsity(fn, n)
+    assert nz_set(pat) == dense_hessian_pattern(fn, n)
+
+
+# ---------------------------------------------------------------------------
+# A. fallbacks: linear / constant / zero-dependency → identity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [
+        lambda u: 3.0 * jnp.sum(u),  # linear
+        lambda u: 5.0 + 0.0 * u[0],  # constant
+        lambda u: jnp.sum(jnp.floor(u)),  # zero-dependency primitive (floor)
+        lambda u: jnp.sum(u > 0.0),  # comparison → no deps
+    ],
+    ids=["linear", "constant", "floor", "comparison"],
+)
+def test_zero_hessian_returns_identity(fn):
+    """When nothing couples, ``_trace_hessian_sparsity`` falls back to the identity."""
+    n = 4
+    pat = trace_energy_sparsity(fn, n)
+    assert nz_set(pat) == nz_set(sps.eye(n))
+
+
+# ---------------------------------------------------------------------------
+# B. nonlinear classification (_NONLINEAR_*, integer_pow, linearity exception)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "exponent,records",
+    [(-1, True), (0, False), (1, False), (2, True), (3, True)],
+)
+def test_integer_pow_exponent_classification(exponent, records):
+    """``integer_pow`` only records couplings for exponents >= 2 or <= -1."""
+    # the +2.0 offset keeps the base away from 0 so the reciprocal (y=-1) is well defined
+    fn = lambda u: jnp.sum((u + 2.0) ** exponent)
+    pat = trace_energy_sparsity(fn, 4)
+    if records:
+        # y in {-1, 2, 3}: genuine diagonal curvature is recorded
+        assert nz_set(pat) == {(i, i) for i in range(4)}
+        assert dense_hessian_pattern(fn, 4) <= nz_set(pat)
+    else:
+        # y in {0, 1}: linear/constant → identity fallback only
+        assert nz_set(pat) == nz_set(sps.eye(4))
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [
+        lambda u: jnp.sum(3.0 * u),  # mul by constant
+        lambda u: jnp.sum(u * 2.0),  # mul by constant (other operand)
+        lambda u: jnp.sum(u / 4.0),  # div by constant
+    ],
+    ids=["const_mul_lhs", "const_mul_rhs", "const_div"],
+)
+def test_linear_scaling_not_recorded(fn):
+    """``mul``/``div`` by a constant is linear and must record no couplings."""
+    pat = trace_energy_sparsity(fn, 5)
+    assert nz_set(pat) == nz_set(sps.eye(5))
+
+
+def test_unary_nonlinear_is_separable_diagonal():
+    """An element-wise unary nonlinearity yields a purely diagonal Hessian pattern."""
+    pat = trace_energy_sparsity(lambda u: jnp.sum(jnp.sin(u)), 5)
+    assert nz_set(pat) == {(i, i) for i in range(5)}
+
+
+def test_binary_product_couples_operands():
+    """``u[:-1] * u[1:]`` couples adjacent DOFs (a superset of the off-diagonal pattern)."""
+    n = 5
+    pat = trace_energy_sparsity(lambda u: jnp.sum(u[:-1] * u[1:]), n)
+    # every true adjacency must be captured
+    expected_adjacent = {(i, i + 1) for i in range(n - 1)} | {
+        (i + 1, i) for i in range(n - 1)
+    }
+    assert expected_adjacent <= nz_set(pat)
+
+
+# ---------------------------------------------------------------------------
+# D. higher-order handlers: equivalences and known soundness boundaries
+# ---------------------------------------------------------------------------
+
+
+def test_nested_jit_matches_unjitted():
+    """``@jax.jit`` (and nesting) must not change the traced pattern."""
+    e = lambda u: jnp.sum(u[:-1] * u[1:]) + jnp.sum(jnp.sin(u))
+    base = nz_set(trace_energy_sparsity(e, 6))
+    assert nz_set(trace_energy_sparsity(jax.jit(e), 6)) == base
+    assert nz_set(trace_energy_sparsity(jax.jit(jax.jit(e)), 6)) == base
+
+
+def test_cond_internal_nonlinearity_captured():
+    """The ``cond`` handler traverses branch jaxprs, so a nonlinearity created *inside* a
+    branch and consumed linearly is captured (union of both branches)."""
+    n = 6
+    fn = lambda u: jax.lax.cond(
+        u[0] > 0,
+        lambda v: jnp.sum(v[:-1] * v[1:]),  # tridiagonal coupling
+        lambda v: jnp.sum(v**2),  # diagonal
+        u,
+    )
+    pat = trace_energy_sparsity(fn, n)
+    assert dense_hessian_pattern(fn, n) <= nz_set(pat)
+    # union of a tridiagonal and a diagonal branch is exactly the tridiagonal pattern
+    assert nz_set(pat) == dense_hessian_pattern(fn, n)
+
+
+def test_cond_nonlinearity_after_branch_is_sound():
+    """A nonlinearity applied *after* the cond (affine branches) is also captured."""
+    n = 6
+    fn = lambda u: jnp.sum(
+        jax.lax.cond(u[0] > 0, lambda v: v * 2.0, lambda v: v[::-1] * 3.0, u) ** 2
+    )
+    assert dense_hessian_pattern(fn, n) <= nz_set(trace_energy_sparsity(fn, n))
+
+
+def test_switch_multibranch_captured():
+    """``switch`` lowers to a multi-branch ``cond``; every branch is traced and unioned."""
+    n = 6
+    fn = lambda u: jax.lax.switch(
+        jnp.int32(jnp.clip(u[0], 0, 2)),
+        [
+            lambda v: jnp.sum(v**2),
+            lambda v: jnp.sum(v[:-1] * v[1:]),
+            lambda v: jnp.sum(jnp.sin(v)),
+        ],
+        u,
+    )
+    assert dense_hessian_pattern(fn, n) <= nz_set(trace_energy_sparsity(fn, n))
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="scan_map seeds the carry with empty deps: a data-dependent carry coupling "
+    "across iterations is not tracked (false negatives). Map-style scans are sound.",
+)
+def test_scan_carry_coupling_is_unsound():
+    """Documents a soundness boundary: cross-iteration coupling via a scan carry."""
+    n = 6
+    fn = lambda u: jnp.sum(jax.lax.scan(lambda c, x: (x, c * x), 1.0, u)[1])
+    assert dense_hessian_pattern(fn, n) <= nz_set(trace_energy_sparsity(fn, n))
+
+
+# ---------------------------------------------------------------------------
+# E. virtual-work trial/test split machinery
+# ---------------------------------------------------------------------------
+
+
+def test_virtual_work_bad_argument_name_raises():
+    """An unknown ``trial_arg`` / ``test_arg`` name is rejected up front."""
+    g = lambda w, u: jnp.sum(w * u)
+    with pytest.raises(ValueError, match="Trial argument 'x' not found"):
+        trace_virtual_work_sparsity(g, 3, trial_arg="x", test_arg="w")
+    with pytest.raises(ValueError, match="Test argument 'y' not found"):
+        trace_virtual_work_sparsity(g, 3, trial_arg="u", test_arg="y")
+
+
+def test_virtual_work_excludes_trial_only_term():
+    """A trial-only nonlinear term must not leak into the cross-block tangent K."""
+    n = 4
+    # cross term w*u (→ diagonal K) plus a trial-only nonlinearity u**2 that must be masked
+    g = lambda w, u: jnp.sum(w * u) + jnp.sum(u**2)
+    K = trace_virtual_work_sparsity(g, n, trial_arg="u", test_arg="w")
+    assert nz_set(K) == {(i, i) for i in range(n)}
+
+
+def test_virtual_work_static_arg_forwarded():
+    """Extra ``*static_args`` are forwarded positionally to the virtual-work function."""
+    n = 4
+    g = lambda w, u, kappa: jnp.sum(kappa * w[:-1] * u[1:])
+    K = trace_virtual_work_sparsity(g, n, "u", "w", 2.0)
+    assert dense_vw_pattern(lambda w, u: g(w, u, 2.0), n) <= nz_set(K)
+    assert K.nnz > 0  # the static coefficient does not zero-out the coupling
+
+
+def test_virtual_work_default_arg_used():
+    """A parameter with a default is filled from the signature when not supplied."""
+    n = 4
+    g = lambda w, u, kappa=3.0: jnp.sum(kappa * w[:-1] * u[1:])
+    K = trace_virtual_work_sparsity(g, n, "u", "w")
+    assert dense_vw_pattern(lambda w, u: g(w, u), n) <= nz_set(K)
+
+
+def test_virtual_work_missing_static_arg_raises():
+    """A non-defaulted extra parameter with no supplied static arg is an error."""
+    n = 3
+    g = lambda w, u, kappa: jnp.sum(kappa * w * u)
+    with pytest.raises(ValueError, match="Missing static argument"):
+        trace_virtual_work_sparsity(g, n, "u", "w")
+
+
+def test_virtual_work_unsymmetric_pattern_captured():
+    """A one-way cross coupling yields a genuinely unsymmetric K, captured with no
+    false negatives (the path that distinguishes the VW tracer from the energy tracer)."""
+    n = 4
+    # w_i couples to u_{i+1} but not the reverse → strictly upper off-diagonal block
+    g = lambda w, u: jnp.sum(w[:-1] * u[1:])
+    K = trace_virtual_work_sparsity(g, n, trial_arg="u", test_arg="w")
+    ref = dense_vw_pattern(g, n)
+    assert ref <= nz_set(K)
+    assert nz_set(K) != {(c, r) for (r, c) in nz_set(K)}  # not symmetric
+
+
+# ---------------------------------------------------------------------------
+# F. small unit tests of the data structures and helpers
+# ---------------------------------------------------------------------------
+
+
+def test_unwrap_jit_unwraps_jit_but_preserves_other_transforms():
+    """``_unwrap_jit`` strips ``jax.jit`` wrappers but leaves ``grad``/``vmap`` intact."""
+    e = lambda u: jnp.sum(u**2)
+    assert _unwrap_jit(jax.jit(e)) is e
+    assert _unwrap_jit(jax.jit(jax.jit(e))) is e
+    assert _unwrap_jit(e) is e
+
+    g = jax.grad(e)
+    assert _unwrap_jit(g) is g  # grad must NOT be unwrapped to its primal
+
+
+def test_sparse_dep_set_singletons_and_empty():
+    s = SparseDepSet.singletons(3)
+    assert s.shape == (3,)
+    assert s.dep.shape == (3, 3)
+    assert s.dep.nnz == 3
+    np.testing.assert_array_equal(s.dep.toarray(), np.eye(3, dtype=bool))
+
+    e = SparseDepSet.empty((2, 2), 3)
+    assert e.shape == (2, 2)
+    assert e.dep.shape == (4, 3)
+    assert e.dep.nnz == 0
+
+
+def test_sparse_dep_set_total_union_and_reshape():
+    s = SparseDepSet.singletons(4)
+    union = s.total_union()
+    assert union.shape == ()
+    assert union.dep.nnz == 4  # all four DOFs active after OR-reduction
+
+    reshaped = SparseDepSet.singletons(6).reshape(2, 3)
+    assert reshaped.shape == (2, 3)
+    assert reshaped.dep.shape == (6, 6)  # underlying dep is unchanged by reshape
+
+
+def test_sparse_dep_set_broadcast_to_replicates_rows():
+    one_row = SparseDepSet(sps.csr_matrix(np.array([[1, 0, 1]], dtype=bool)), (1,))
+    out = one_row.broadcast_to((4,))
+    assert out.shape == (4,)
+    assert out.dep.shape == (4, 3)
+    np.testing.assert_array_equal(
+        out.dep.toarray(), np.tile(np.array([[1, 0, 1]], dtype=bool), (4, 1))
+    )
+
+
+def test_coupling_accumulator_fingerprint_dedup():
+    """Recording an identical dependency structure twice must not duplicate coordinates."""
+    acc = CouplingAccumulator(3)
+    dep = sps.csr_matrix(np.array([[1, 0, 0], [0, 1, 0]], dtype=bool))
+    acc.record_dep(dep)
+    acc.record_dep(dep)  # same fingerprint → skipped
+    pat = acc.finalize()
+    assert pat.dtype == np.int8
+    assert nz_set(pat) == {(0, 0), (1, 1)}
+    assert set(pat.data.tolist()) == {1}  # binarized
+
+
+def test_coupling_accumulator_trial_test_split_mask():
+    """With a split, only cross pairs (one DOF on each side) are retained."""
+    acc = CouplingAccumulator(4)
+    full_row = sps.csr_matrix(np.ones((1, 4), dtype=bool))
+    acc.record_dep(full_row, trial_test_split=2)
+    pat = acc.finalize()
+    expected = {(r, c) for r in range(4) for c in range(4) if (r < 2) != (c < 2)}
+    assert nz_set(pat) == expected
+
+
+def test_coupling_accumulator_empty_finalize():
+    acc = CouplingAccumulator(3)
+    pat = acc.finalize()
+    assert pat.shape == (3, 3)
+    assert pat.nnz == 0
+    assert pat.dtype == np.int8

--- a/tests/test_sparse_tracer_core.py
+++ b/tests/test_sparse_tracer_core.py
@@ -471,3 +471,150 @@ def test_coupling_accumulator_empty_finalize():
     assert pat.shape == (3, 3)
     assert pat.nnz == 0
     assert pat.dtype == np.int8
+
+
+# ---------------------------------------------------------------------------
+# G. opaque-leaf handlers: custom_vjp/jvp, host callbacks, debug, ffi_call
+# ---------------------------------------------------------------------------
+#
+# These leaves are opaque to the tracer (no traceable jaxpr / no host-side rule).
+# The contract: couple all *active inputs of the call* conservatively -- which, when each
+# call sees only one element's local DOFs, is exactly the per-element pattern. The shared
+# adjacent-difference energy below makes every call's input {i, i+1}, so the conservative
+# coupling is the (tight) tridiagonal pattern.
+
+
+def _adjacent_energy(leaf, M):
+    """``sum_i leaf(U[i] - U[i+1])`` -- each opaque call's input is the local pair {i,i+1}."""
+
+    def energy(U):
+        e = 0.0
+        for i in range(M - 1):
+            e = e + leaf(U[i] - U[i + 1])
+        return jnp.sum(e)
+
+    return energy
+
+
+def _tridiagonal(M) -> set[tuple[int, int]]:
+    s = {(i, i) for i in range(M)}
+    s |= {(i, i + 1) for i in range(M - 1)}
+    s |= {(i + 1, i) for i in range(M - 1)}
+    return s
+
+
+def test_custom_jvp_leaf_conservative_and_tight():
+    """A ``custom_jvp`` leaf is treated as an opaque nonlinear box: it couples its input
+    DOFs, giving the tridiagonal pattern with no false negatives vs the true Hessian."""
+    M = 6
+
+    @jax.custom_jvp
+    def leaf(x):
+        return 0.5 * x**2
+
+    @leaf.defjvp
+    def leaf_jvp(primals, tangents):
+        (x,), (dx,) = primals, tangents
+        return leaf(x), x * dx
+
+    fn = _adjacent_energy(leaf, M)
+    pat = pattern_from_energy(fn, M)
+    assert nz_set(pat) == _tridiagonal(M)
+    assert dense_hessian_pattern(fn, M) <= nz_set(pat)  # no false negatives
+
+
+def test_custom_vjp_leaf_hides_iteration_but_couples_inputs():
+    """A ``custom_vjp`` leaf hiding an iterative solve is opaque to the tracer; it still
+    records the conservative coupling of its inputs (tridiagonal)."""
+    M = 6
+
+    @jax.custom_vjp
+    def leaf(x):
+        y = x
+        for _ in range(5):  # hidden Newton iteration, invisible to the tracer
+            y = y - (y**3 + y - x) / (3 * y**2 + 1.0)
+        return 0.5 * y**2
+
+    def leaf_fwd(x):
+        y = x
+        for _ in range(5):
+            y = y - (y**3 + y - x) / (3 * y**2 + 1.0)
+        return 0.5 * y**2, y
+
+    def leaf_bwd(res, g):
+        y = res
+        return (g * y / (3 * y**2 + 1.0),)
+
+    leaf.defvjp(leaf_fwd, leaf_bwd)
+
+    fn = _adjacent_energy(leaf, M)
+    # The tracer must not descend into the loop: a custom_vjp_call jaxpr is present.
+    prims = {e.primitive.name for e in jax.make_jaxpr(fn)(np.zeros(M)).jaxpr.eqns}
+    assert "custom_vjp_call" in prims
+    assert nz_set(pattern_from_energy(fn, M)) == _tridiagonal(M)
+
+
+@pytest.mark.parametrize("ordered_kind", ["pure", "io"])
+def test_host_callback_leaf_records_couplings(ordered_kind):
+    """``pure_callback`` / ``io_callback`` get the dedicated opaque handler, so couplings
+    are RECORDED (the plain fallback would silently drop them, leaving only the diagonal)."""
+    from jax.experimental import io_callback
+
+    M = 6
+
+    def leaf(x):
+        sds = jax.ShapeDtypeStruct(x.shape, x.dtype)
+        if ordered_kind == "pure":
+            return jax.pure_callback(lambda v: 0.5 * v**2, sds, x)
+        return io_callback(lambda v: 0.5 * v**2, sds, x, ordered=True)
+
+    pat = pattern_from_energy(_adjacent_energy(leaf, M), M)
+    assert nz_set(pat) == _tridiagonal(M)
+    assert pat.nnz > M  # off-diagonals present -> couplings were NOT silently dropped
+
+
+def test_debug_print_is_noop():
+    """``jax.debug.print`` is an effect-only (no-output) primitive: it must neither change
+    the pattern nor break tracing."""
+    M = 6
+    base = lambda U: jnp.sum(U[:-1] * U[1:])
+
+    def with_print(U):
+        jax.debug.print("tracing U with shape {}", U.shape)
+        return jnp.sum(U[:-1] * U[1:])
+
+    assert nz_set(pattern_from_energy(with_print, M)) == nz_set(pattern_from_energy(base, M))
+
+
+def test_ffi_call_default_dense_registered_block_diagonal():
+    """A vmapped ``ffi_call`` is a single batched opaque call -> global dense by default;
+    after ``register_elementwise_ffi`` it is treated as elementwise along the vmap axis
+    -> the sparse (tridiagonal) per-element pattern. (The FFI is never executed during
+    tracing, so no compiled target is needed.)"""
+    import jax.ffi as jffi
+
+    from tatva.sparse import register_elementwise_ffi
+    from tatva.sparse.tracer import _ELEMENTWISE_FFI_TARGETS
+
+    M = 6
+    target = "tatva_unittest_rve"
+
+    def leaf(s):  # per quad point: (n_dim,) -> (n_dim,)
+        return jffi.ffi_call(
+            target, jax.ShapeDtypeStruct(s.shape, s.dtype), vmap_method="broadcast_all"
+        )(s)
+
+    def energy(U):
+        strain = (U[:-1] - U[1:]).reshape(-1, 1)  # (M-1, n_dim=1)
+        return jnp.sum(jax.vmap(leaf)(strain) * strain)
+
+    try:
+        assert target not in _ELEMENTWISE_FFI_TARGETS
+        pat_dense = pattern_from_energy(energy, M)
+        assert pat_dense.nnz == M * M  # conservative global dense
+
+        register_elementwise_ffi(target)
+        pat_sparse = pattern_from_energy(energy, M)
+        assert nz_set(pat_sparse) == _tridiagonal(M)
+    finally:
+        _ELEMENTWISE_FFI_TARGETS.discard(target)


### PR DESCRIPTION
**Description of Changes**
 
This PR simplifies and unifies the sparsity pattern generation API across the codebase. It introduces automatic JAX-trace-based sparsity detection directly from energy and virtual work formulations, moves sparsity generation logic out of the       
 `Compound` class, and consolidates sparsity augmentation/reduction under the `Lifter` class.
  
 ## Breaking Changes
  
 * **Removed/Deprecated Sparse APIs**: The following helper functions have been removed from `tatva.sparse` and will now raise an `ImportError` if called:
      * `create_sparsity_pattern` (replaced by `pattern_from_mesh`)
      * `reduce_sparsity_pattern` (replaced by `Lifter.adapt_sparsity`)
      * `create_sparsity_pattern_KKT`
      * `create_sparsity_pattern_master_slave`
      * `get_bc_indices`
 * **Compound Sparsity Method Removed**: Removed the class method `Compound.get_sparsity()` to decouple structure layout from sparsity generation.
 * **Coloring Functions Hidden**: Removed `distance2_colors`, `largest_degree_first_distance2_colors`, and `smallest_last_distance2_colors` from the public `tatva.sparse` namespace.
  
 ## New Features & Refactoring
  
  * **Automatic JAX Sparsity Tracing**:
      * `pattern_from_energy(energy_fn, n_dofs, *static_args)`: Automatically traces and returns the symmetric CSR sparsity pattern of the Hessian (d²E/du²) for a scalar energy function.
      * `pattern_from_virtual_work(virtual_work_fn, n_dofs, trial_arg, test_arg, *static_args)`: Automatically traces and returns the tangent stiffness matrix sparsity pattern (d²G/dvdu) from a virtual work function.
 * **Unified Sparsity Extraction Helpers**:
      * `pattern_from_mesh(mesh, n_dofs_per_node)`: Standardized mesh-based sparsity generation.
      * `pattern_from_compound(compound_cls, block_wise=False)`: Extracted compound class sparsity generation to the sparse module.
* **Unified Reduction and Constraint Handling**:
      * Added `Lifter.adapt_sparsity(sparsity)` to automate both the augmentation (adding master-slave coupling) and reduction (retaining only free DOFs) of a sparsity pattern in a single call.
  

## Usage Examples (Tracer with Boundary Conditions)                                                                                                                                                                                                  
                                                                                                                                                                                                                                                            
By passing a `Lifter` as a static argument, you can trace the sparsity of the reduced system (accounting for boundary conditions) directly:


### 1. Energy-Based Tracer with BCs                                                                                                                                                                                                                     

```python                                                                                                                                                                                                                                               
    import jax                                                                                                                                                                                                                                              
    import jax.numpy as jnp                                                                                                                                                                                                                                 
    from tatva.sparse import pattern_from_energy                                                                                                                                                                                                            
                                                                                                                                                                                                                                                            
    @jax.jit                                                                                                                                                                                                                                                
    def total_energy(u):                                                                                                                                                                                                                                    
        # Compute full potential energy                                                                                                                                                                                                                     
        return ...                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                            
    @jax.jit                                                                                                                                                                                                                                                
    def energy_free(u_free, lf):                                                                                                                                                                                                                            
        # Map free DOFs to full state accounting for BCs                                                                                                                                                                                                    
        u_full = lf.lift_from_zeros(u_free)                                                                                                                                                                                                                 
        return total_energy(u_full)                                                                                                                                                                                                                         
  
    # Trace sparsity of the reduced Hessian directly
    traced_reduced_sparsity = pattern_from_energy(
        energy_free, 
        lifter.size_reduced, 
        lifter  # Passed as static_args
    )
 ```
  
 ### 2. Virtual Work-Based Tracer with BCs
 

 ```python
    import jax
    import jax.numpy as jnp
    from tatva.sparse import pattern_from_virtual_work
  
    @jax.jit
    def virtual_work(test, trial):
        # Compute virtual work G(test, trial)
        return ...
  
    @jax.jit
    def virtual_work_free(test_free, trial_free, lf):
        # Map free trial and test variables to full states
        test_full = lf.lift_from_zeros(test_free)
        trial_full = lf.lift_from_zeros(trial_free)
        return virtual_work(test_full, trial_full)
  
    # Trace sparsity of the reduced tangent stiffness matrix directly
    traced_reduced_sparsity = pattern_from_virtual_work(
        virtual_work_free,
        lifter.size_reduced,
        "trial_free",
        "test_free",
        lifter  # Passed as static_args
    )
 ```
  



 ## Migration Examples
  
  ### 1. Mesh Sparsity
 
```diff
-sparsity = sparse.create_sparsity_pattern(mesh, n_dofs_per_node=2)
+sparsity = sparse.pattern_from_mesh(mesh, n_dofs_per_node=2)
```

  ### 2. Compound Sparsity
  
```diff
-sparsity = MyCompound.get_sparsity()
+sparsity = sparse.pattern_from_compound(MyCompound)
```

 ### 3. Reduction & Constraints
  
```diff
-sparsity = sparse.reduce_sparsity_pattern(
-    sparse.create_sparsity_pattern(mesh, 2),
-      lifter.free_dofs
-)
+sparsity = lifter.adapt_sparsity(
+    sparse.pattern_from_compound(MyCompound))
```

**Checklist:**
- [x] I have read the contributing guidelines.
- [x] My code follows the style guidelines of this project. `tatva` uses `ruff`.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have commented my code, particularly in hard-to-understand areas.
