### PR TITLE
fix: adds missing case for dot_general jnp.dot

### DIFF
--- a/tatva/sparse/tracer.py
+++ b/tatva/sparse/tracer.py
@@ -1504,19 +1504,24 @@ class Handlers:
                 dtype=bool,
             )
 
-            # Record A and B self-couplings via accumulator (fingerprint-cached)
-            acc.record_dep(A_active, trial_test_split)
-            acc.record_dep(B_active, trial_test_split)
+            # A batched contraction is bilinear: it couples only when BOTH
+            # operands depend on the input. If either is constant (no active
+            # DOFs) the contraction is linear -> record no couplings. Covers
+            # both (const, var) and (var, const).
+            if A_active.nnz and B_active.nnz:
+                # Record A and B self-couplings via accumulator (fingerprint-cached)
+                acc.record_dep(A_active, trial_test_split)
+                acc.record_dep(B_active, trial_test_split)
 
-            # Cross-couplings between A and B (no fingerprint cache - structurally distinct)
-            P_cross = (A_active.T @ B_active).tocsr()
-            r_c, c_c = P_cross.nonzero()
-            if trial_test_split is not None:
-                mask_c = (r_c < trial_test_split) & (c_c >= trial_test_split)
-                mask_c |= (r_c >= trial_test_split) & (c_c < trial_test_split)
-                r_c, c_c = r_c[mask_c], c_c[mask_c]
-            acc.add_coords(r_c, c_c)
-            acc.add_coords(c_c, r_c)
+                # Cross-couplings between A and B (no fingerprint cache - structurally distinct)
+                P_cross = (A_active.T @ B_active).tocsr()
+                r_c, c_c = P_cross.nonzero()
+                if trial_test_split is not None:
+                    mask_c = (r_c < trial_test_split) & (c_c >= trial_test_split)
+                    mask_c |= (r_c >= trial_test_split) & (c_c < trial_test_split)
+                    r_c, c_c = r_c[mask_c], c_c[mask_c]
+                acc.add_coords(r_c, c_c)
+                acc.add_coords(c_c, r_c)
 
             # Vectorized construction of stacked output dependencies
             C_active = (A_active + B_active).astype(bool).tocsr()
@@ -1528,12 +1533,19 @@ class Handlers:
             ua = in_d[0].total_union()
             ub = in_d[1].total_union()
 
-            ua.record_couplings(acc, trial_test_split)
-            ub.record_couplings(acc, trial_test_split)
-
             ia = ua.dep.indices
             ib = ub.dep.indices
+            # A contraction dot(a, b) is bilinear, so it contributes second-order
+            # coupling only when BOTH operands depend on the input. If either
+            # operand is constant (empty dep-set) the contraction is linear in the
+            # other and has zero Hessian -> record no couplings. This guard covers
+            # both (const, var) and (var, const). Same-operand nonlinearity is
+            # already captured upstream at the primitive that made it nonlinear, so
+            # only the bilinear cross-term needs to be recorded here.
             if ia.size and ib.size:
+                ua.record_couplings(acc, trial_test_split)
+                ub.record_couplings(acc, trial_test_split)
+
                 # Vectorized outer-product of active DOF indices for cross-couplings
                 r_c = np.repeat(ia, ib.size)
                 c_c = np.tile(ib, ia.size)

--- a/tests/test_sparse_tracer_core.py
+++ b/tests/test_sparse_tracer_core.py
@@ -251,6 +251,40 @@ def test_linear_scaling_not_recorded(fn):
     assert nz_set(pat) == nz_set(sps.eye(5))
 
 
+_DOT_C5 = jnp.arange(1.0, 6.0)  # constant vector
+_DOT_M5 = jnp.arange(1.0, 26.0).reshape(5, 5)  # constant matrix
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [
+        lambda u: jnp.dot(_DOT_C5, u),  # dot(const, var)
+        lambda u: jnp.dot(u, _DOT_C5),  # dot(var, const)
+        lambda u: jnp.sum(_DOT_M5 @ u),  # constant matrix-vector contraction
+    ],
+    ids=["dot_const_lhs", "dot_const_rhs", "const_matvec"],
+)
+def test_dot_general_constant_operand_not_recorded(fn):
+    """A ``dot_general`` contraction with a constant operand is linear and has zero
+    Hessian, so it must record no couplings — for *both* ``dot(const, u)`` and
+    ``dot(u, const)``. Regression for the dense-pattern bug where the handler
+    recorded each operand's self-coupling unconditionally; ``dot(f_ext, u.ravel())``
+    then collapsed all DOFs into one clique and produced a fully dense pattern.
+    """
+    pat = pattern_from_energy(fn, 5)
+    assert nz_set(pat) == nz_set(sps.eye(5))
+
+
+def test_dot_general_bilinear_still_couples():
+    """The constant-operand fix must not introduce false negatives: a genuine
+    quadratic form ``uᵀ M u`` (a contraction where *both* operands depend on the
+    input) must still record the full coupling."""
+    n = 5
+    fn = lambda u: u @ _DOT_M5 @ u
+    pat = pattern_from_energy(fn, n)
+    assert dense_hessian_pattern(fn, n) <= nz_set(pat)
+
+
 def test_unary_nonlinear_is_separable_diagonal():
     """An element-wise unary nonlinearity yields a purely diagonal Hessian pattern."""
     pat = pattern_from_energy(lambda u: jnp.sum(jnp.sin(u)), 5)


### PR DESCRIPTION
When an energy included a force term like `jnp.dot(f_ext, u)`, the sparsity tracer wrongly marked every DOF as connected to every other one, making the matrix fully dense. 

The reason was that the code that handles `dot_general` (matrix/vector products) always assumed both inputs were variables. But here, one input (`f_ext`) is a constant, so the term is just linear and adds nothing to the stiffness pattern.

The fix adds to the `dot_general` handler to skip the coupling when one side is a constant. Now `jnp.dot(const, u)` and `jnp.dot(u, const)` stay sparse, while real `jnp.dot(u, u)` products still get coupled correctly. Added tests to cover both cases.


**Checklist:**
- [x] I have read the contributing guidelines.
- [x] My code follows the style guidelines of this project. `tatva` uses `ruff`.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have commented my code, particularly in hard-to-understand areas.
