### PR TITLE
Fix/sparsity pattern gating

### DIFF
--- a/tatva/sparse/tracer.py
+++ b/tatva/sparse/tracer.py
@@ -293,6 +293,21 @@ _NONLINEAR_BINARY = frozenset(
     }
 )
 
+# Dense nonlinear linear-algebra primitives: the leaf ops that back jnp.linalg.inv/solve/
+# det(large)/cholesky. Each is a dense nonlinear map of its matrix argument — every output
+# entry depends on all input entries and those input DOFs mutually couple. Treated as one
+# dense black box (see Handlers.dense_linalg); classified nonlinear so its inputs are
+# traced and its curvature is recorded rather than silently dropped by the generic fallback.
+_DENSE_LINALG = frozenset(
+    {
+        "lu",
+        "custom_linear_solve",
+        "triangular_solve",
+        "lu_solve",
+        "cholesky",
+    }
+)
+
 
 def _prim_introduces_nonlinearity(eqn: JaxprEqn, invar_active: list[bool]) -> bool:
     """Whether this primitive makes its output a *non-affine* function of ``u``.
@@ -327,6 +342,8 @@ def _prim_introduces_nonlinearity(eqn: JaxprEqn, invar_active: list[bool]) -> bo
         "io_callback",
         "ffi_call",
     ):
+        return any(invar_active)
+    if p in _DENSE_LINALG:
         return any(invar_active)
     return False
 
@@ -668,7 +685,7 @@ def _analyze_and_resolve_jaxpr(
                 "pure_callback",
                 "io_callback",
                 "ffi_call",
-            ):
+            ) or p in _DENSE_LINALG:
                 combined_mask = 0
                 for v in eqn.invars:
                     combined_mask |= tags.get(id(v), 0)
@@ -693,7 +710,7 @@ def _analyze_and_resolve_jaxpr(
                 "pure_callback",
                 "io_callback",
                 "ffi_call",
-            ):
+            ) or p in _DENSE_LINALG:
                 is_nonlinear = True
 
         # Seed active variables if it is a nonlinear primitive
@@ -1277,6 +1294,32 @@ class Handlers:
         state.set(eqn.outvars[0], SparseDepSet(stacked_dep[concat_idx], oshp))
 
     @staticmethod
+    @TRACER_REGISTRY.register("stack")
+    def stack(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        """``stack`` inserts a new axis and places input ``i`` at position ``i`` along it —
+        purely structural, so each stacked slice keeps its own per-element support (no
+        globalizing union, no couplings). Same construction as ``concatenate`` but the
+        input blocks are laid out along a *new* axis rather than concatenated on an
+        existing one.
+        """
+        in_d = [state.get(v) for v in eqn.invars]
+        oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
+        idx_arrays = []
+        offset = 0
+        for b in in_d:
+            size = int(np.prod(b.shape))
+            idx_arrays.append(np.arange(size).reshape(b.shape) + offset)
+            offset += size
+        stacked_dep = sps.vstack([b.dep for b in in_d], format="csr")
+        stack_idx = np.stack(idx_arrays, axis=eqn.params["axis"]).ravel()
+        state.set(eqn.outvars[0], SparseDepSet(stacked_dep[stack_idx], oshp))
+
+    @staticmethod
     @TRACER_REGISTRY.register("pad")
     def pad(
         eqn: JaxprEqn,
@@ -1424,6 +1467,51 @@ class Handlers:
 
         if not is_linear:
             combined.record_couplings(acc, trial_test_split)
+
+    @staticmethod
+    @TRACER_REGISTRY.register(*_DENSE_LINALG)
+    def dense_linalg(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        """Dense nonlinear linear-algebra primitives (``lu`` / ``custom_linear_solve`` /
+        ``triangular_solve`` / ``lu_solve`` / ``cholesky``) — the leaf ops behind
+        ``jnp.linalg.inv`` / ``solve`` / ``cholesky``.
+
+        Each is a *dense* nonlinear map: every output entry depends on the union of all
+        solution-dependent input entries, and — being nonlinear — those input DOFs mutually
+        couple (a full Hessian block over the union). We treat the op as one dense black
+        box: union the solution-dependent inputs, record that union's self outer-product,
+        and give every output element the union support. It is conservative, but these ops
+        act on small element-local matrices whose DOFs already form a dense block in the
+        element stiffness, so in practice it adds no real fill. Without a handler these
+        primitives fell to the generic fallback, which records *no* couplings and can drop
+        the op's curvature (false negatives) when its result is not re-coupled downstream.
+        """
+        in_d = [state.get(v) for v in eqn.invars]
+        cols = np.zeros(state.n_dofs, dtype=bool)
+        for d in in_d:
+            if d.dep.shape[0] and d.dep.nnz:
+                cols[d.dep.indices] = True
+        union_row = sps.csr_matrix(cols.reshape(1, -1))
+
+        # Dense self-coupling over the union: a real Hessian block for a nonlinear op.
+        # record_dep computes union_rowᵀ @ union_row -> the full union×union block.
+        if union_row.nnz:
+            acc.record_dep(union_row, trial_test_split)
+
+        # Every output element (all outputs, e.g. lu's LU/pivots/permutation) depends on
+        # the whole union.
+        for ov in eqn.outvars:
+            oshp = _get_shape(ov)
+            state.set(
+                ov,
+                SparseDepSet(
+                    _broadcast_single_row(union_row, int(np.prod(oshp))), oshp
+                ),
+            )
 
     @staticmethod
     @TRACER_REGISTRY.register("integer_pow")

--- a/tatva/sparse/tracer.py
+++ b/tatva/sparse/tracer.py
@@ -295,9 +295,9 @@ _NONLINEAR_BINARY = frozenset(
 )
 
 # Dense nonlinear linear-algebra primitives: the leaf ops that back jnp.linalg.inv/solve/
-# det(large)/cholesky. Each is a dense nonlinear map of its matrix argument — every output
-# entry depends on all input entries and those input DOFs mutually couple. Treated as one
-# dense black box (see Handlers.dense_linalg); classified nonlinear so its inputs are
+# det(large)/cholesky/eig(h). Each is a dense nonlinear map of its matrix argument — every
+# output entry depends on all input entries and those input DOFs mutually couple. Treated as
+# one dense black box (see Handlers.dense_linalg); classified nonlinear so its inputs are
 # traced and its curvature is recorded rather than silently dropped by the generic fallback.
 _DENSE_LINALG = frozenset(
     {
@@ -306,6 +306,8 @@ _DENSE_LINALG = frozenset(
         "triangular_solve",
         "lu_solve",
         "cholesky",
+        "eig",
+        "eigh",
     }
 )
 
@@ -1197,6 +1199,8 @@ class Handlers:
         "stop_gradient",
         "device_put",
         "conj",
+        "real",
+        "imag",
     )
     def passthrough(
         eqn,
@@ -1333,6 +1337,28 @@ class Handlers:
         stacked_dep = sps.vstack([b.dep for b in in_d], format="csr")
         stack_idx = np.stack(idx_arrays, axis=eqn.params["axis"]).ravel()
         state.set(eqn.outvars[0], SparseDepSet(stacked_dep[stack_idx], oshp))
+
+    @staticmethod
+    @TRACER_REGISTRY.register("rev")
+    def rev(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        """``rev`` (``jnp.flip``) reverses element order along the given axes — a pure
+        permutation, so it just reorders the dependency rows and keeps each element's own
+        support (structural, no couplings)."""
+        d = state.get(eqn.invars[0])
+        shape = d.shape
+        dims = eqn.params["dimensions"]
+        src = np.arange(int(np.prod(shape))).reshape(shape)
+        slicer = tuple(
+            slice(None, None, -1) if ax in dims else slice(None)
+            for ax in range(len(shape))
+        )
+        rev_idx = src[slicer].ravel()
+        state.set(eqn.outvars[0], SparseDepSet(d.dep[rev_idx], shape))
 
     @staticmethod
     @TRACER_REGISTRY.register("pad")

--- a/tatva/sparse/tracer.py
+++ b/tatva/sparse/tracer.py
@@ -152,7 +152,9 @@ def _dot_general_out_dep(
         # conservative whole-array union rather than risk a mismatch.
         combined = sps.csr_matrix((lhs.dep + rhs.dep).astype(bool))
         return SparseDepSet(
-            _broadcast_single_row(sps.csr_matrix(combined.sum(axis=0).astype(bool)), n_out),
+            _broadcast_single_row(
+                sps.csr_matrix(combined.sum(axis=0).astype(bool)), n_out
+            ),
             oshp,
         )
 
@@ -173,8 +175,10 @@ def _dot_general_out_dep(
         else np.zeros(n_out, int)
     )
     out_dep = (
-        lhs_red[lhs_keys].astype(np.int8) + rhs_red[rhs_keys].astype(np.int8)
-    ).astype(bool).tocsr()
+        (lhs_red[lhs_keys].astype(np.int8) + rhs_red[rhs_keys].astype(np.int8))
+        .astype(bool)
+        .tocsr()
+    )
     return SparseDepSet(out_dep, oshp)
 
 
@@ -680,15 +684,19 @@ def _analyze_and_resolve_jaxpr(
                 if exponent >= 2 or exponent <= -1:
                     if tags.get(id(eqn.invars[0]), 0) == 3:
                         is_nonlinear = True
-            elif p in (
-                "dot_general",
-                "scatter-mul",
-                "custom_vjp_call",
-                "custom_jvp_call",
-                "pure_callback",
-                "io_callback",
-                "ffi_call",
-            ) or p in _DENSE_LINALG:
+            elif (
+                p
+                in (
+                    "dot_general",
+                    "scatter-mul",
+                    "custom_vjp_call",
+                    "custom_jvp_call",
+                    "pure_callback",
+                    "io_callback",
+                    "ffi_call",
+                )
+                or p in _DENSE_LINALG
+            ):
                 combined_mask = 0
                 for v in eqn.invars:
                     combined_mask |= tags.get(id(v), 0)
@@ -705,15 +713,19 @@ def _analyze_and_resolve_jaxpr(
                 exponent = eqn.params.get("y", 0)
                 if exponent >= 2 or exponent <= -1:
                     is_nonlinear = True
-            elif p in (
-                "dot_general",
-                "scatter-mul",
-                "custom_vjp_call",
-                "custom_jvp_call",
-                "pure_callback",
-                "io_callback",
-                "ffi_call",
-            ) or p in _DENSE_LINALG:
+            elif (
+                p
+                in (
+                    "dot_general",
+                    "scatter-mul",
+                    "custom_vjp_call",
+                    "custom_jvp_call",
+                    "pure_callback",
+                    "io_callback",
+                    "ffi_call",
+                )
+                or p in _DENSE_LINALG
+            ):
                 is_nonlinear = True
 
         # Seed active variables if it is a nonlinear primitive

--- a/tatva/sparse/tracer.py
+++ b/tatva/sparse/tracer.py
@@ -16,6 +16,7 @@
 # along with tatva.  If not, see <https://www.gnu.org/licenses/>.
 
 import inspect
+import warnings
 from collections.abc import Callable, Sequence
 from typing import Any, Concatenate, ParamSpec
 
@@ -1136,6 +1137,20 @@ class Handlers:
         if not has_active:
             total = SparseDepSet.empty((), state.n_dofs)
         else:
+            # This primitive carries a solution dependence but has no handler, so we can
+            # only over-approximate its first-order support and cannot record its
+            # second-order couplings -> possible false negatives if the result is not
+            # re-coupled by a downstream nonlinear primitive. Flag it so an unhandled
+            # primitive does not silently degrade the pattern.
+            warnings.warn(
+                f"Sparsity tracer has no handler for primitive "
+                f"'{eqn.primitive.name}'; falling back to a conservative first-order "
+                "approximation (second-order couplings not recorded, which can cause "
+                "false negatives if the result is not re-coupled by a downstream "
+                "nonlinear primitive). Register a handler for this primitive to make "
+                "the pattern exact.",
+                UserWarning,
+            )
             reduced = sps.csr_matrix(cols_active.reshape(1, -1))
             total = SparseDepSet(reduced, ())
         stacked_dep = _broadcast_single_row(total.dep, int(np.prod(oshp)))

--- a/tatva/sparse/tracer.py
+++ b/tatva/sparse/tracer.py
@@ -197,6 +197,43 @@ _NONLINEAR_BINARY = frozenset(
 )
 
 
+def _prim_introduces_nonlinearity(eqn: JaxprEqn, invar_active: list[bool]) -> bool:
+    """Whether this primitive makes its output a *non-affine* function of ``u``.
+
+    Mirrors exactly the sites where the tracer records second-order couplings, so a
+    variable is flagged nonlinear iff a coupling-recording primitive touched it. Every
+    other (structural / additive) primitive is affine-preserving and returns ``False`` --
+    nonlinearity then only reaches the output via a nonlinear *input* (handled by the
+    caller). ``invar_active[i]`` is whether input ``i`` depends on ``u``.
+    """
+    p = eqn.primitive.name
+    if p in _NONLINEAR_UNARY:
+        return bool(invar_active) and invar_active[0]
+    if p == "integer_pow":
+        y = eqn.params.get("y", 0)
+        return (y >= 2 or y <= -1) and bool(invar_active) and invar_active[0]
+    if p in ("mul", "scatter-mul"):
+        # bilinear: nonlinear only if *both* factors depend on u (scaling by a
+        # constant stays affine)
+        return sum(invar_active) >= 2
+    if p == "div":
+        # x / c is affine; nonlinear only when the divisor depends on u
+        return len(invar_active) > 1 and invar_active[1]
+    if p in _NONLINEAR_BINARY:  # pow, rem, atan2, igamma, igammac, nextafter, complex
+        return any(invar_active)
+    if p == "dot_general":
+        return sum(invar_active) >= 2
+    if p in (
+        "custom_vjp_call",
+        "custom_jvp_call",
+        "pure_callback",
+        "io_callback",
+        "ffi_call",
+    ):
+        return any(invar_active)
+    return False
+
+
 class TracerRegistry:
     """Registry for JAX primitive dependency propagation handlers."""
 
@@ -317,6 +354,7 @@ class TraceState:
         active_ids: set[int],
         tags: dict | None = None,
         sub_info: dict | None = None,
+        nonlinear_ids: set[int] | None = None,
     ):
         """
         Args:
@@ -327,6 +365,13 @@ class TraceState:
                 1=trial-only, 2=test-only, 3=both); used for trial/test splitting
             sub_info: dict to store sub-jaxpr analysis results for nested jits; maps eqn
                 IDs to (active_set, resolved_eqns)
+            nonlinear_ids: set of variable IDs that are a *non-affine* (nonlinear) function
+                of the input ``u``. A variable enters this set when a coupling-recording
+                (second-order) primitive touches its computation from ``u``. Shared across
+                nested sub-states so operand nonlinearity propagates across jit/cond/scan
+                boundaries. Used to gate the self-couplings recorded by bilinear
+                contractions (``dot_general``): an affine operand has zero second
+                derivative, so its self outer-product is not a real Hessian block.
         """
         self.n_dofs = n_dofs
         self.active_ids = active_ids
@@ -334,6 +379,39 @@ class TraceState:
         self.dep_of: dict[int, SparseDepSet] = {}
         self.val_of: dict[int, np.ndarray] = {}
         self.sub_info = sub_info if sub_info is not None else {}
+        self.nonlinear_ids = nonlinear_ids if nonlinear_ids is not None else set()
+
+    def is_nonlinear(self, var) -> bool:
+        """Whether ``var`` is a non-affine (nonlinear) function of the input ``u``."""
+        return id(var) in self.nonlinear_ids
+
+    def mark_nonlinear(self, eqn: JaxprEqn) -> None:
+        """Flag ``eqn``'s outputs as nonlinear if a coupling-recording primitive touches
+        their computation, or if any input is already nonlinear.
+
+        Conservative: it only ever *adds* nonlinearity (over-flagging keeps a self-coupling
+        that is at worst redundant), so it can never cause a bilinear contraction to drop a
+        real second-order block. Higher-order primitives (jit/cond/scan) propagate their
+        sub-jaxpr's nonlinearity explicitly in their handlers, so they are skipped here.
+        """
+        if not eqn.outvars or eqn.primitive.name in (
+            "pjit",
+            "jit",
+            "scan",
+            "map",
+            "remat2",
+            "cond",
+            "switch",
+            "while",
+        ):
+            return
+        out_nl = any(id(v) in self.nonlinear_ids for v in eqn.invars)
+        if not out_nl:
+            invar_active = [self.get(v).dep.nnz > 0 for v in eqn.invars]
+            out_nl = _prim_introduces_nonlinearity(eqn, invar_active)
+        if out_nl:
+            for ov in eqn.outvars:
+                self.nonlinear_ids.add(id(ov))
 
     def set(self, var, d: SparseDepSet) -> None:
         """Associate dep-set with a JAX variable."""
@@ -699,6 +777,7 @@ def _trace_hessian_sparsity(
             continue
 
         handler(eqn, state, acc, trial_test_split)
+        state.mark_nonlinear(eqn)
 
         # Propagate concrete value for executed equations as well (essential for active gather/scatter routing)
         if ovars:
@@ -1509,9 +1588,15 @@ class Handlers:
             # DOFs) the contraction is linear -> record no couplings. Covers
             # both (const, var) and (var, const).
             if A_active.nnz and B_active.nnz:
-                # Record A and B self-couplings via accumulator (fingerprint-cached)
-                acc.record_dep(A_active, trial_test_split)
-                acc.record_dep(B_active, trial_test_split)
+                # Self-couplings (A.T@A / B.T@B) are real Hessian blocks only for an
+                # operand that is itself a *nonlinear* function of u -- and in that case
+                # they are already recorded upstream at the primitive that made it
+                # nonlinear. An affine operand has zero second derivative, so its self
+                # outer-product is spurious; record it only for nonlinear operands.
+                if state.is_nonlinear(eqn.invars[0]):
+                    acc.record_dep(A_active, trial_test_split)
+                if state.is_nonlinear(eqn.invars[1]):
+                    acc.record_dep(B_active, trial_test_split)
 
                 # Cross-couplings between A and B (no fingerprint cache - structurally distinct)
                 P_cross = (A_active.T @ B_active).tocsr()
@@ -1539,12 +1624,18 @@ class Handlers:
             # coupling only when BOTH operands depend on the input. If either
             # operand is constant (empty dep-set) the contraction is linear in the
             # other and has zero Hessian -> record no couplings. This guard covers
-            # both (const, var) and (var, const). Same-operand nonlinearity is
-            # already captured upstream at the primitive that made it nonlinear, so
-            # only the bilinear cross-term needs to be recorded here.
+            # both (const, var) and (var, const). The self outer-products ua.T@ua /
+            # ub.T@ub are real Hessian blocks only when that operand is itself a
+            # *nonlinear* function of u (and are then already recorded upstream at the
+            # primitive that made it nonlinear); for an affine operand the second
+            # derivative vanishes, so recording the self-product is spurious. Hence
+            # gate each self-recording on operand nonlinearity and always record the
+            # bilinear cross-term.
             if ia.size and ib.size:
-                ua.record_couplings(acc, trial_test_split)
-                ub.record_couplings(acc, trial_test_split)
+                if state.is_nonlinear(eqn.invars[0]):
+                    ua.record_couplings(acc, trial_test_split)
+                if state.is_nonlinear(eqn.invars[1]):
+                    ub.record_couplings(acc, trial_test_split)
 
                 # Vectorized outer-product of active DOF indices for cross-couplings
                 r_c = np.repeat(ia, ib.size)
@@ -1646,7 +1737,9 @@ class Handlers:
 
         # Seed sub-state with symbolic dependencies for mapped inputs
         sub_active, sub_bound_eqns = state.sub_info[id(eqn)]
-        sub_state = TraceState(n_local_dofs, sub_active, {}, state.sub_info)
+        sub_state = TraceState(
+            n_local_dofs, sub_active, {}, state.sub_info, state.nonlinear_ids
+        )
 
         # Seed consts: empty deps
         for i in range(num_const):
@@ -1654,6 +1747,8 @@ class Handlers:
                 sub.invars[i],
                 SparseDepSet.empty(_get_shape(sub.invars[i]), n_local_dofs),
             )
+            if state.is_nonlinear(eqn.invars[i]):
+                sub_state.nonlinear_ids.add(id(sub.invars[i]))
             val = state.get_val(eqn.invars[i])
             if val is not None:
                 sub_state.val_of[id(sub.invars[i])] = val
@@ -1711,6 +1806,8 @@ class Handlers:
             sub_state.set(
                 sub.invars[num_const + num_carry + k], SparseDepSet(sub_dep, shp)
             )
+            if state.is_nonlinear(eqn.invars[num_const + num_carry + k]):
+                sub_state.nonlinear_ids.add(id(sub.invars[num_const + num_carry + k]))
 
             # Set a representative concrete value from element 0
             val = state.get_val(eqn.invars[num_const + num_carry + k])
@@ -1733,6 +1830,7 @@ class Handlers:
                 continue
 
             sub_handler(sub_eqn, sub_state, sub_acc, None)
+            sub_state.mark_nonlinear(sub_eqn)
 
             if sub_ovars:
                 in_vals = [sub_state.get_val(v) for v in sub_eqn.invars]
@@ -1888,6 +1986,8 @@ class Handlers:
 
                 y_shape = (length,) + slice_shape
                 state.set(y, SparseDepSet(expanded_dep, y_shape))
+                if sub_state.is_nonlinear(sub_y):
+                    state.nonlinear_ids.add(id(y))
 
     @staticmethod
     @TRACER_REGISTRY.register("pjit", "jit", "remat2")
@@ -1911,10 +2011,16 @@ class Handlers:
         sub_active, sub_bound_eqns = state.sub_info[id(eqn)]
 
         n_dofs = state.n_dofs
-        sub_state = TraceState(n_dofs, sub_active, state.tags, state.sub_info)
+        sub_state = TraceState(
+            n_dofs, sub_active, state.tags, state.sub_info, state.nonlinear_ids
+        )
 
         for v, d in zip(sub.invars, in_d):
             sub_state.set(v, d)
+        # Carry operand nonlinearity across the jit boundary onto the sub-invars.
+        for pv, sv in zip(eqn.invars, sub.invars):
+            if state.is_nonlinear(pv):
+                sub_state.nonlinear_ids.add(id(sv))
         for v, c in zip(sub.constvars, sub_consts):
             sub_state.set(v, SparseDepSet.empty(_get_shape(v), n_dofs))
             sub_state.val_of[id(v)] = np.asarray(c)
@@ -1932,6 +2038,7 @@ class Handlers:
                 continue
 
             sub_handler(sub_eqn, sub_state, acc, trial_test_split)
+            sub_state.mark_nonlinear(sub_eqn)
 
             # Propagate concrete value for executed equations as well
             if ovars:
@@ -1942,6 +2049,8 @@ class Handlers:
 
         for pv, sv in zip(eqn.outvars, sub.outvars):
             state.set(pv, sub_state.get(sv))
+            if sub_state.is_nonlinear(sv):
+                state.nonlinear_ids.add(id(pv))
 
     @staticmethod
     @TRACER_REGISTRY.register("cond")
@@ -1971,12 +2080,16 @@ class Handlers:
         ):
             sub = branch.jaxpr
             sub_consts = branch.consts
-            sub_state = TraceState(n_dofs, sub_active, state.tags, state.sub_info)
+            sub_state = TraceState(
+                n_dofs, sub_active, state.tags, state.sub_info, state.nonlinear_ids
+            )
 
             # Seed branch invars with operand dep-sets and concrete values (the latter
             # are needed to route any gather/scatter indices inside the branch).
             for sv, d, ov in zip(sub.invars, in_d, operands):
                 sub_state.set(sv, d)
+                if state.is_nonlinear(ov):
+                    sub_state.nonlinear_ids.add(id(sv))
                 val = state.get_val(ov)
                 if val is not None:
                     sub_state.val_of[id(sv)] = val
@@ -1996,6 +2109,7 @@ class Handlers:
                     continue
 
                 sub_handler(sub_eqn, sub_state, acc, trial_test_split)
+                sub_state.mark_nonlinear(sub_eqn)
 
                 if ovars:
                     in_vals = [sub_state.get_val(v) for v in sub_eqn.invars]
@@ -2005,6 +2119,8 @@ class Handlers:
 
             for ov, sv in zip(eqn.outvars, sub.outvars):
                 d = sub_state.get(sv)
+                if sub_state.is_nonlinear(sv):
+                    state.nonlinear_ids.add(id(ov))
                 prev = out_deps[id(ov)]
                 if prev is None:
                     out_deps[id(ov)] = d

--- a/tatva/sparse/tracer.py
+++ b/tatva/sparse/tracer.py
@@ -80,6 +80,103 @@ def _broadcast_single_row(row: sps.csr_matrix, N: int) -> sps.csr_matrix:
     return sps.csr_matrix((data, indices, indptr), shape=(N, row.shape[1]))
 
 
+def _reduce_union_over_axes(
+    dep: sps.csr_matrix, shape: tuple[int, ...], keep_axes: list[int]
+) -> sps.csr_matrix:
+    """OR-reduce a dep-array over all axes NOT in ``keep_axes``.
+
+    ``dep`` is a (prod(shape), n_dofs) CSR whose rows are the row-major flattening of a
+    tensor of logical ``shape``. Returns a (prod(shape[keep_axes]), n_dofs) CSR whose rows
+    are the row-major flattening over ``keep_axes`` (in the given order), where each kept
+    row is the union of the dependency sets of every original element that maps to it.
+
+    This is the exact support map for a reduction (a summed-out axis makes the result
+    depend on the union along it), so it only ever preserves or tightens support -- never
+    drops a real dependency.
+    """
+    n_rows = dep.shape[0]
+    if not keep_axes:
+        # Reducing over everything -> single-row total union.
+        return sps.csr_matrix(dep.sum(axis=0).astype(bool)) if n_rows else dep
+    orig = np.arange(n_rows)
+    multi = np.unravel_index(orig, shape) if shape else (np.zeros(n_rows, int),)
+    keep_dims = tuple(shape[a] for a in keep_axes)
+    key = np.ravel_multi_index(tuple(multi[a] for a in keep_axes), keep_dims)
+    n_keys = int(np.prod(keep_dims))
+    # Boolean aggregation matrix (n_keys x n_rows); (agg @ dep) unions the rows per key.
+    agg = sps.csr_matrix(
+        (np.ones(n_rows, dtype=np.int8), (key, orig)), shape=(n_keys, n_rows)
+    )
+    return (agg @ dep.astype(np.int8)).astype(bool).tocsr()
+
+
+def _dot_general_out_dep(
+    lhs: "SparseDepSet",
+    rhs: "SparseDepSet",
+    lhs_c: Sequence[int],
+    rhs_c: Sequence[int],
+    lhs_b: Sequence[int],
+    rhs_b: Sequence[int],
+    oshp: tuple[int, ...],
+    n_dofs: int,
+) -> "SparseDepSet":
+    """Structure-preserving support propagation for a ``dot_general``.
+
+    Output element ``out[b, fl, fr]`` (batch ``b``, lhs-free ``fl``, rhs-free ``fr``)
+    depends on exactly ``(union_c lhs[b, fl, c]) | (union_c rhs[b, c, fr])``. We reduce
+    each operand over its contracting axes, then broadcast the two reduced dep-tensors to
+    the output layout ``[batch..., lhs_free..., rhs_free...]`` (JAX's ``dot_general`` output
+    order) and union them. This keeps per-row (per-element) support instead of collapsing
+    to the whole-array ``total_union`` -- the difference between a locally-supported field
+    and one that appears to depend on every DOF.
+    """
+    La, Lb = lhs.shape, rhs.shape
+    lhs_b, rhs_b = list(lhs_b), list(rhs_b)
+    lhs_c, rhs_c = list(lhs_c), list(rhs_c)
+    lhs_free = [a for a in range(len(La)) if a not in lhs_b and a not in lhs_c]
+    rhs_free = [a for a in range(len(Lb)) if a not in rhs_b and a not in rhs_c]
+
+    # Reduce out contracting axes, keeping (batch, free) in output order.
+    lhs_red = _reduce_union_over_axes(lhs.dep, La, lhs_b + lhs_free)
+    rhs_red = _reduce_union_over_axes(rhs.dep, Lb, rhs_b + rhs_free)
+
+    batch_sizes = tuple(La[a] for a in lhs_b)
+    lhs_free_sizes = tuple(La[a] for a in lhs_free)
+    rhs_free_sizes = tuple(Lb[a] for a in rhs_free)
+    out_dims = batch_sizes + lhs_free_sizes + rhs_free_sizes
+
+    n_out = int(np.prod(oshp))
+    if int(np.prod(out_dims)) != n_out:
+        # Shape bookkeeping disagrees with the reported output shape; fall back to the
+        # conservative whole-array union rather than risk a mismatch.
+        combined = sps.csr_matrix((lhs.dep + rhs.dep).astype(bool))
+        return SparseDepSet(
+            _broadcast_single_row(sps.csr_matrix(combined.sum(axis=0).astype(bool)), n_out),
+            oshp,
+        )
+
+    nb, nlf = len(lhs_b), len(lhs_free)
+    omulti = np.unravel_index(np.arange(n_out), out_dims) if out_dims else ()
+    batch_m = omulti[:nb]
+    lf_m = omulti[nb : nb + nlf]
+    rf_m = omulti[nb + nlf :]
+
+    lhs_keys = (
+        np.ravel_multi_index(batch_m + lf_m, batch_sizes + lhs_free_sizes)
+        if (batch_sizes + lhs_free_sizes)
+        else np.zeros(n_out, int)
+    )
+    rhs_keys = (
+        np.ravel_multi_index(batch_m + rf_m, batch_sizes + rhs_free_sizes)
+        if (batch_sizes + rhs_free_sizes)
+        else np.zeros(n_out, int)
+    )
+    out_dep = (
+        lhs_red[lhs_keys].astype(np.int8) + rhs_red[rhs_keys].astype(np.int8)
+    ).astype(bool).tocsr()
+    return SparseDepSet(out_dep, oshp)
+
+
 class CouplingAccumulator:
     """Accumulates Hessian coupling pairs as numpy-array chunks; fingerprints dep matrices
     to skip redundant recordings."""
@@ -1540,15 +1637,21 @@ class Handlers:
         in_d = [state.get(v) for v in eqn.invars]
         oshp = _get_shape(eqn.outvars[0]) if eqn.outvars else ()
 
-        # Determine if there is a batch axis
+        # Determine contracting and batch axes
         dn = eqn.params.get("dimension_numbers")
         lhs_batch = []
         rhs_batch = []
+        lhs_contract = []
+        rhs_contract = []
         if dn is not None:
             if hasattr(dn, "lhs_batch_dimensions"):
                 lhs_batch = dn.lhs_batch_dimensions
                 rhs_batch = dn.rhs_batch_dimensions
+                lhs_contract = dn.lhs_contracting_dimensions
+                rhs_contract = dn.rhs_contracting_dimensions
             elif len(dn) > 1:
+                lhs_contract = dn[0][0]
+                rhs_contract = dn[0][1]
                 lhs_batch = dn[1][0]
                 rhs_batch = dn[1][1]
 
@@ -1649,9 +1752,21 @@ class Handlers:
                 acc.add_coords(r_c, c_c)
                 acc.add_coords(c_c, r_c)
 
-            combined = sps.csr_matrix((ua.dep + ub.dep).astype(bool))
-            stacked_dep = _broadcast_single_row(combined, int(np.prod(oshp)))
-            state.set(eqn.outvars[0], SparseDepSet(stacked_dep, oshp))
+            # Propagate output support preserving per-element (free-dimension) structure
+            # rather than broadcasting the whole-array union to every output element. This
+            # keeps a locally-supported contraction (e.g. ``field @ normal`` with a constant
+            # normal) local, instead of making every output component depend on all DOFs.
+            out_dep = _dot_general_out_dep(
+                in_d[0],
+                in_d[1],
+                lhs_contract,
+                rhs_contract,
+                lhs_batch,
+                rhs_batch,
+                oshp,
+                state.n_dofs,
+            )
+            state.set(eqn.outvars[0], out_dep)
 
     @staticmethod
     @TRACER_REGISTRY.register("cond", "switch", "while")

--- a/tests/test_sparse_tracer.py
+++ b/tests/test_sparse_tracer.py
@@ -611,9 +611,7 @@ def test_ffi_leaf_virtual_work_register_elementwise(line_operator):
     def g_elastic(w, u):
         (u_n,) = Field(u)
         (w_n,) = Field(w)
-        return op.integrate(
-            jnp.einsum("eqd,eqd->eq", op.grad(u_n), op.grad(w_n))
-        ).sum()
+        return op.integrate(jnp.einsum("eqd,eqd->eq", op.grad(u_n), op.grad(w_n))).sum()
 
     ref = pattern_from_virtual_work(g_elastic, Field.size, trial_arg="u", test_arg="w")
     try:

--- a/tests/test_sparse_tracer_core.py
+++ b/tests/test_sparse_tracer_core.py
@@ -17,6 +17,8 @@ captured). One genuine soundness boundary remains documented as ``xfail``:
   * a data-dependent *carry* coupling in ``lax.scan``.
 """
 
+import warnings
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -408,6 +410,39 @@ def test_stack_preserves_per_slice_support():
     traced = nz_set(pat)
     assert dense_hessian_pattern(energy, n) <= traced  # no false negatives
     assert _cross_segment_pairs(traced, block) == set()  # no cross-slice globalization
+
+
+def test_generic_fallback_warns_on_unhandled_primitive():
+    """A primitive the tracer has no handler for — here ``eigvalsh`` (→ ``eigh``) — carrying
+    a solution dependence must not degrade the pattern silently: the generic fallback
+    over-approximates support and records no couplings, so it emits a ``UserWarning`` naming
+    the primitive. This is the signal that would catch the next unhandled-primitive gap.
+    """
+
+    def energy(u):
+        A = u.reshape(3, 3)
+        A = A + A.T
+        return jnp.sum(jnp.linalg.eigvalsh(A) ** 2)
+
+    with pytest.warns(UserWarning, match=r"no handler for primitive 'eigh'"):
+        pattern_from_energy(energy, 9)
+
+
+def test_no_fallback_warning_for_handled_primitives():
+    """A fully-handled energy (inv + stack + element-wise nonlinears) must emit no
+    fallback warning — the handlers keep the generic fallback silent, so its warning stays
+    clean signal rather than noise."""
+
+    def energy(u):
+        A = u.reshape(3, 3) + 5.0 * jnp.eye(3)
+        return jnp.sum(jnp.linalg.inv(A)) + jnp.sum(
+            jnp.stack([jnp.sin(u[0]) * u[1]]) ** 2
+        )
+
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        pattern_from_energy(energy, 9)
+    assert not [w for w in rec if "no handler for primitive" in str(w.message)]
 
 
 def test_unary_nonlinear_is_separable_diagonal():

--- a/tests/test_sparse_tracer_core.py
+++ b/tests/test_sparse_tracer_core.py
@@ -799,7 +799,9 @@ def test_debug_print_is_noop():
         jax.debug.print("tracing U with shape {}", U.shape)
         return jnp.sum(U[:-1] * U[1:])
 
-    assert nz_set(pattern_from_energy(with_print, M)) == nz_set(pattern_from_energy(base, M))
+    assert nz_set(pattern_from_energy(with_print, M)) == nz_set(
+        pattern_from_energy(base, M)
+    )
 
 
 def test_ffi_call_default_dense_registered_block_diagonal():

--- a/tests/test_sparse_tracer_core.py
+++ b/tests/test_sparse_tracer_core.py
@@ -22,6 +22,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 import scipy.sparse as sps
+from jax_autovmap import autovmap
 
 from tatva.sparse import pattern_from_energy, pattern_from_virtual_work
 from tatva.sparse.tracer import (
@@ -283,6 +284,88 @@ def test_dot_general_bilinear_still_couples():
     fn = lambda u: u @ _DOT_M5 @ u
     pat = pattern_from_energy(fn, n)
     assert dense_hessian_pattern(fn, n) <= nz_set(pat)
+
+
+def _cross_segment_pairs(pairs: set, block: int) -> set:
+    """The subset of ``(row, col)`` pairs that couple DOFs of *different* segments,
+    where segment = ``dof // block``."""
+    return {(r, c) for (r, c) in pairs if r // block != c // block}
+
+
+@pytest.mark.parametrize("d", [2, 3], ids=["2d-normal", "3d-normal"])
+def test_dot_general_batched_matvec_preserves_locality(d):
+    """A batched ``field @ const`` contraction must keep per-segment (batch-row) support
+    instead of collapsing to the whole-array union.
+
+    This is the minimal reproduction of the Nitsche-interface blow-up: a per-segment
+    ``stress_avg`` (here a symmetric ``d×d`` tensor, affine in that segment's DOFs only)
+    is contracted with a *constant* normal to form a ``traction``, which then enters a
+    bilinear ``traction·jump`` term. Because every segment reads only its own DOFs, the
+    true Hessian is block-diagonal (one ``d²×d²`` block per segment) with **no**
+    cross-segment coupling. Before the fix the ``dot_general`` fallback broadcast the
+    total union to every output, so ``traction`` appeared to depend on all DOFs and the
+    pattern saturated to fully dense — an over-approximation that grows ~linearly with the
+    number of segments. Parametrised over a 2D and a 3D normal to mirror the 2D/3D
+    fracture examples.
+    """
+    N = 6  # interface segments
+    b = d * d  # DOFs per segment (a full d×d "stress" tensor)
+    n = N * b
+    normal = jnp.arange(1.0, d + 1)
+
+    def energy(u):
+        S = u.reshape(N, d, d)
+        S = 0.5 * (S + jnp.swapaxes(S, 1, 2))  # symmetric, still segment-local & affine
+        traction = S @ normal  # (N, d) batched matvec with a constant  <-- under test
+        jump = S[:, 0, :]  # (N, d) per-segment jump, segment-local
+        return jnp.sum(traction * jump)  # bilinear traction·jump summed over segments
+
+    pat = pattern_from_energy(energy, n)
+    traced = nz_set(pat)
+
+    # No false negatives: the traced pattern contains the true Hessian.
+    assert dense_hessian_pattern(energy, n) <= traced
+    # The regression guard: the pattern must stay block-diagonal per segment. A single
+    # cross-segment entry means ``traction``'s support globalized (the old behaviour).
+    assert _cross_segment_pairs(traced, b) == set()
+    # Locality => nnz is linear in the segment count, never the dense N²·b².
+    assert pat.nnz <= N * b * b
+
+
+@pytest.mark.parametrize("d", [2, 3], ids=["2d-normal", "3d-normal"])
+def test_dot_general_batched_matvec_locality_under_autovmap(d):
+    """Same per-segment locality when the contraction is written per-element and lifted by
+    ``autovmap`` — the way the Nitsche interface density is actually expressed — with the
+    normal captured as a *global closure constant* rather than an argument.
+
+    ``autovmap`` adds a leading batch axis over the segments, but the constant normal still
+    reaches ``dot_general`` with no batch dimension and an empty dep-set, so it is
+    indistinguishable (at the primitive) from the non-vmapped case above and the support
+    propagation stays block-diagonal. This guards the closure-constant / vmapped framing
+    explicitly, since it is the one used in practice.
+    """
+    N = 6
+    b = d * d
+    n = N * b
+    normal = jnp.arange(1.0, d + 1)  # global closure constant, NOT an autovmap argument
+
+    @autovmap(stress_avg=2)
+    def density(stress_avg):
+        traction = stress_avg @ normal  # constant captured; vmapped over segments
+        jump = stress_avg[0, :]
+        return jnp.dot(traction, jump)
+
+    def energy(u):
+        S = u.reshape(N, d, d)
+        S = 0.5 * (S + jnp.swapaxes(S, 1, 2))  # symmetric, segment-local & affine
+        return jnp.sum(density(S))
+
+    pat = pattern_from_energy(energy, n)
+    traced = nz_set(pat)
+
+    assert dense_hessian_pattern(energy, n) <= traced  # no false negatives
+    assert _cross_segment_pairs(traced, b) == set()  # no support globalization
+    assert pat.nnz <= N * b * b  # linear, never dense
 
 
 def test_unary_nonlinear_is_separable_diagonal():

--- a/tests/test_sparse_tracer_core.py
+++ b/tests/test_sparse_tracer_core.py
@@ -368,6 +368,48 @@ def test_dot_general_batched_matvec_locality_under_autovmap(d):
     assert pat.nnz <= N * b * b  # linear, never dense
 
 
+@pytest.mark.parametrize("op", ["inv", "solve"], ids=["inv", "solve"])
+def test_dense_linalg_couples_when_consumed_linearly(op):
+    """``jnp.linalg.inv`` / ``solve`` are dense nonlinear maps. Even when the result is
+    consumed by only a *linear* reduction — so no downstream nonlinearity re-couples its
+    support — the handler must record the op's own curvature.
+
+    These lower to ``lu`` / ``custom_linear_solve``. Without a handler they hit the generic
+    fallback, which records *no* second-order couplings, and the true dense block collapses
+    to the diagonal → false negatives. With the ``dense_linalg`` handler the full block is
+    recorded. Regression for that soundness gap.
+    """
+    n = 9
+    if op == "inv":
+        fn = lambda u: jnp.sum(jnp.linalg.inv(u.reshape(3, 3) + 5.0 * jnp.eye(3)))
+    else:
+        b = jnp.arange(1.0, 4.0)
+        fn = lambda u: jnp.sum(jnp.linalg.solve(u.reshape(3, 3) + 5.0 * jnp.eye(3), b))
+    pat = pattern_from_energy(fn, n)
+    assert dense_hessian_pattern(fn, n) <= nz_set(pat)  # no false negatives
+
+
+def test_stack_preserves_per_slice_support():
+    """``stack`` is structural: each stacked slice keeps its own support, so a later
+    nonlinearity couples only *within* a slice, not across all of them. Without a handler
+    the generic fallback unions all inputs into every output element, so the downstream
+    ``**2`` would couple every slice to every other — a spurious dense block. Regression for
+    the ``stack`` handler.
+    """
+    N, block = 4, 2
+    n = block * N
+
+    def energy(u):
+        # slice i is a nonlinear scalar depending only on DOFs {2i, 2i+1}
+        parts = [jnp.sin(u[2 * i]) * u[2 * i + 1] for i in range(N)]
+        return jnp.sum(jnp.stack(parts) ** 2)
+
+    pat = pattern_from_energy(energy, n)
+    traced = nz_set(pat)
+    assert dense_hessian_pattern(energy, n) <= traced  # no false negatives
+    assert _cross_segment_pairs(traced, block) == set()  # no cross-slice globalization
+
+
 def test_unary_nonlinear_is_separable_diagonal():
     """An element-wise unary nonlinearity yields a purely diagonal Hessian pattern."""
     pat = pattern_from_energy(lambda u: jnp.sum(jnp.sin(u)), 5)

--- a/tests/test_sparse_tracer_core.py
+++ b/tests/test_sparse_tracer_core.py
@@ -412,20 +412,42 @@ def test_stack_preserves_per_slice_support():
     assert _cross_segment_pairs(traced, block) == set()  # no cross-slice globalization
 
 
+def test_eigh_is_dense_nonlinear_no_false_negatives():
+    """``jnp.linalg.eigh`` (→ ``eigh``) is a dense nonlinear op: every eigenvalue depends on
+    the whole matrix, so consuming it — even linearly — must record the full block. Covers
+    both a nonlinear (``**2``) and a purely linear (``sum``) consumer."""
+    for consume in (lambda w: jnp.sum(w**2), lambda w: jnp.sum(w)):
+        fn = lambda u: consume(jnp.linalg.eigvalsh(u.reshape(3, 3) + u.reshape(3, 3).T))
+        pat = pattern_from_energy(fn, 9)
+        assert dense_hessian_pattern(fn, 9) <= nz_set(pat)  # no false negatives
+
+
+def test_rev_preserves_support():
+    """``rev`` (``jnp.flip``) is a structural permutation: it reorders dependencies without
+    unioning or coupling them. ``sum(flip(u) * u)`` couples DOF i with n-1-i and nothing
+    else — a pure anti-diagonal, which the generic-fallback union would have smeared dense."""
+    n = 6
+    fn = lambda u: jnp.sum(jnp.flip(u) * u)
+    pat = pattern_from_energy(fn, n)
+    traced = nz_set(pat)
+    assert dense_hessian_pattern(fn, n) <= traced  # no false negatives
+    # locality: every coupling is self or mirror only — never the dense block the
+    # generic-fallback union of flip(u) would have produced.
+    assert all(c in (r, n - 1 - r) for (r, c) in traced)
+
+
 def test_generic_fallback_warns_on_unhandled_primitive():
-    """A primitive the tracer has no handler for — here ``eigvalsh`` (→ ``eigh``) — carrying
-    a solution dependence must not degrade the pattern silently: the generic fallback
-    over-approximates support and records no couplings, so it emits a ``UserWarning`` naming
-    the primitive. This is the signal that would catch the next unhandled-primitive gap.
+    """A primitive the tracer has no handler for — here ``sort`` — carrying a solution
+    dependence must not degrade the pattern silently: the generic fallback over-approximates
+    support and records no couplings, so it emits a ``UserWarning`` naming the primitive.
+    This is the signal that would catch the next unhandled-primitive gap.
     """
 
     def energy(u):
-        A = u.reshape(3, 3)
-        A = A + A.T
-        return jnp.sum(jnp.linalg.eigvalsh(A) ** 2)
+        return jnp.sum(jnp.sort(u) ** 2)  # 'sort' has no handler; **2 makes it active
 
-    with pytest.warns(UserWarning, match=r"no handler for primitive 'eigh'"):
-        pattern_from_energy(energy, 9)
+    with pytest.warns(UserWarning, match=r"no handler for primitive 'sort'"):
+        pattern_from_energy(energy, 6)
 
 
 def test_no_fallback_warning_for_handled_primitives():


### PR DESCRIPTION
This PR adds handlers for missing primitives for JAX linear algebra operations at the element level, such as `jnp.linalg.inv`, `jnp.linalg.eig` and also for `jnp.flip` and `jnp.stack`.  In this PR, we fix the edge cases with `dot_general`  such as:

-  over-conservatism if one of the operands is just linearly dependent on the solution. Such a case was never checked for how the operand is dependent on the solution because only a nonlinear dependency will lead to a non-zero Hessian entry. The fix records an operand's self-second-order coupling only if it is nonlinear in the solution; the cross second-order coupling between operands is always kept. 
-  when we `dot_general` contract a value that depends on the solution with a constant for example `stress @ n` (per segment stress times a fixed normal) along an interface, the tracer switched to fallback option as it didnot understand which axes the primitive `dot_general` was contracting over and fallback on `total_union` and hence assumed the results depends on every degree of freedom which made the sparsity pattern dense block. The fix tells `dot_general` which axis is being summed over, so dependencies are combined only along the axis and thus the pattern stays block-diagonal, and no real entry is lost.

This PR also adds a warning for the primitives that are not considered. 

**Checklist:**
- [x] I have read the contributing guidelines.
- [x] My code follows the style guidelines of this project. `tatva` uses `ruff`.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have commented my code, particularly in hard-to-understand areas.
