### PR TITLE
Add `make_interpolate` & add `jnp.split` primitive to tracer

### DIFF
--- a/tatva/operator.py
+++ b/tatva/operator.py
@@ -396,15 +396,15 @@ class Operator(Generic[ElementT]):
 
         return self._vmap_over_elements_and_quads(nodal_values, _gradient_quad)
 
-    def interpolate(self, arg: jax.Array, points: jax.Array) -> jax.Array:
-        """Interpolates nodal values to a set of points in the physical space.
+    def make_interpolate(self, points: jax.Array) -> Callable[[jax.Array], jax.Array]:
+        """Returns a function that interpolates nodal values to a set of static points.
 
         Args:
-            arg: The nodal values to interpolate.
-            points: The points to interpolate the function or nodal values to.
+            points: The statically known points to interpolate to.
 
         Returns:
-            A `jax.Array` with the interpolated values at the given points.
+            A function that takes nodal values (`arg`) and returns the interpolated values
+            at the statically known points.
         """
 
         @jax.jit
@@ -445,10 +445,9 @@ class Operator(Generic[ElementT]):
                 valid_indices,
             )
 
-        valid_quad_points, valid_elements, valid_indices = map_physical_to_reference(
+        xi_in_valid_element, valid_elements, valid_indices = map_physical_to_reference(
             points
         )
-        interpolated = self._interpolate_direct(arg, valid_quad_points, valid_elements)
 
         try:
             if bool(jnp.any(~valid_indices)):
@@ -458,22 +457,40 @@ class Operator(Generic[ElementT]):
         except TracerBoolConversionError:
             pass
 
-        mask = valid_indices.reshape(
-            (valid_indices.shape[0],) + (1,) * (interpolated.ndim - 1)
-        )
-        return jnp.where(mask, interpolated, jnp.nan)
+        def interpolate_fn(arg: jax.Array) -> jax.Array:
+            interpolated = self._interpolate_direct(
+                arg, xi_in_valid_element, valid_elements
+            )
+            mask = valid_indices.reshape(
+                (valid_indices.shape[0],) + (1,) * (interpolated.ndim - 1)
+            )
+            return jnp.where(mask, interpolated, jnp.nan)
+
+        return interpolate_fn
+
+    def interpolate(self, arg: jax.Array, points: jax.Array) -> jax.Array:
+        """Interpolates nodal values to a set of points in the physical space.
+
+        Args:
+            arg: The nodal values to interpolate.
+            points: The points to interpolate the function or nodal values to.
+
+        Returns:
+            A `jax.Array` with the interpolated values at the given points.
+        """
+        return self.make_interpolate(points)(arg)
 
     def _interpolate_direct(
         self,
         nodal_values: jax.Array,
-        valid_quad_points: jax.Array,
+        xi_in_valid_element: jax.Array,
         valid_elements: jax.Array,
     ) -> jax.Array:
         """Interpolates the given nodal values at the quad points.
 
         Args:
             nodal_values: The nodal values at the element's nodes (shape: (n_nodes, n_values))
-            valid_quad_points: The quadrature points in the reference element
+            xi_in_valid_element: The points in the reference element
                 (shape: (n_valid_points, n_dim))
             valid_elements: The indices of the elements containing the quadrature points
                 (shape: (n_valid_points,))
@@ -483,19 +500,19 @@ class Operator(Generic[ElementT]):
             each element (shape: (n_valid_points, n_values)).
         """
 
-        def _interpolate_quad(
+        def _interpolate_at_xi(
             xi: jax.Array, el_nodal_values: jax.Array, el_nodal_coords: jax.Array
         ) -> jax.Array:
-            """Calls the function (interpolator) on a quad point."""
+            """Calls the function (interpolator) on arbitrary reference coord."""
             return self.element.interpolate(
                 xi, el_nodal_values, el_nodal_coords
             )  # nodal coords are needed for hermite elements, but not for lagrange elements, so we pass them in either way
 
         return jax.vmap(
-            _interpolate_quad,
+            _interpolate_at_xi,
             in_axes=(0, 0, 0),
         )(
-            valid_quad_points,
+            xi_in_valid_element,
             nodal_values[valid_elements],
             self.mesh.coords[valid_elements],
         )

--- a/tatva/sparse/tracer.py
+++ b/tatva/sparse/tracer.py
@@ -1351,6 +1351,39 @@ class Handlers:
         state.set(eqn.outvars[0], SparseDepSet(stacked_dep[stack_idx], oshp))
 
     @staticmethod
+    @TRACER_REGISTRY.register("split")
+    def split(
+        eqn: JaxprEqn,
+        state: TraceState,
+        acc: "CouplingAccumulator",
+        trial_test_split: int | None,
+    ) -> None:
+        """``split`` (``jnp.split``) cuts one array into several along ``axis`` -- the exact
+        inverse of ``concatenate``, and just as structural: every output element *is* one
+        input element, so it inherits that element's dependency row verbatim (no union, no
+        couplings).
+
+        Handled explicitly because it is a rare multi-output structural primitive:
+        ``Handlers.fallback`` writes only ``outvars[0]``, which would leave every piece but
+        the first with an empty dep-set (silently dropped couplings) while collapsing the
+        first to a whole-array union (a spuriously dense pattern).
+        """
+        d = state.get(eqn.invars[0])
+        axis = eqn.params["axis"]
+        # Row-major positions of the input's elements, laid out in its logical shape, so a
+        # slice of this index array names exactly the dep rows that piece is built from.
+        src_indices = np.arange(int(np.prod(d.shape))).reshape(d.shape)
+        offset = 0
+        for outvar, size in zip(eqn.outvars, eqn.params["sizes"]):
+            size = int(size)
+            oshp = _get_shape(outvar)
+            piece = np.take(
+                src_indices, np.arange(offset, offset + size), axis=axis
+            ).ravel()
+            state.set(outvar, SparseDepSet(d.dep[piece], oshp))
+            offset += size
+
+    @staticmethod
     @TRACER_REGISTRY.register("rev")
     def rev(
         eqn: JaxprEqn,

--- a/tests/test_sparse_tracer_core.py
+++ b/tests/test_sparse_tracer_core.py
@@ -412,6 +412,96 @@ def test_stack_preserves_per_slice_support():
     assert _cross_segment_pairs(traced, block) == set()  # no cross-slice globalization
 
 
+def test_split_preserves_per_piece_support():
+    """``split`` is structural: each piece keeps its own support, so a later nonlinearity
+    couples only *within* a piece. The generic fallback unions the whole input into the
+    first output element, so the downstream ``**2`` would couple every DOF to every other —
+    a spuriously dense block. Regression for the ``split`` handler (false *positives*).
+    """
+    N, block = 4, 2
+    n = block * N
+
+    def energy(u):
+        # piece i is nonlinear in — and only in — DOFs {2i, 2i+1}
+        return sum(jnp.sum(jnp.sin(p[0]) * p[1]) for p in jnp.split(u, N))
+
+    pat = pattern_from_energy(energy, n)
+    traced = nz_set(pat)
+    assert dense_hessian_pattern(energy, n) <= traced  # no false negatives
+    assert _cross_segment_pairs(traced, block) == set()  # no cross-piece globalization
+    assert pat.nnz <= N * block * block  # locality => never the dense n²
+
+
+def test_split_records_couplings_of_every_output_piece():
+    """``split`` is a rare *multi-output* primitive, and ``Handlers.fallback`` writes only
+    ``outvars[0]`` — so without a handler every piece but the first gets an *empty* dep-set
+    and its couplings are silently dropped (false *negatives*, the dangerous direction).
+
+    Here the sole nonlinearity lives in the *last* piece and produces a genuine off-diagonal
+    coupling, so a dropped output cannot be masked by the tracer's ``nnz == 0 -> identity``
+    safety net.
+    """
+    n = 6
+
+    def energy(u):
+        _, _, c = jnp.split(u, 3)
+        return jnp.sum(c[0] * c[1])  # couples DOFs 4 and 5, nothing else
+
+    pat = pattern_from_energy(energy, n)
+    traced = nz_set(pat)
+    assert dense_hessian_pattern(energy, n) <= traced  # the (4,5)/(5,4) block survives
+    assert {(4, 5), (5, 4)} <= traced
+    assert _cross_segment_pairs(traced, 2) == set()
+
+
+@pytest.mark.parametrize("axis", [0, 1], ids=["axis0", "axis1"])
+def test_split_along_axis_matches_equivalent_slicing(axis):
+    """Splitting along a *trailing* axis makes the dep rows a piece inherits strided rather
+    than contiguous, so the handler must slice the row-index map along ``axis`` instead of
+    assuming a flat offset.
+
+    Pinned against the same energy written with plain ``[]`` slicing — which goes through
+    the long-trusted ``slice`` handler — so a misrouted row shows up as a pattern mismatch.
+    Equivalence (not just superset) is the real contract: ``split`` is structural, so it must
+    be *invisible* to the pattern. Asserting only ``true <= traced`` would be satisfied by
+    the dense generic fallback and would not test the routing at all.
+    """
+    n = 8
+
+    def with_split(u):
+        a, b = jnp.split(u.reshape(4, 2), 2, axis=axis)
+        return jnp.sum(a * b) + jnp.sum(jnp.sin(a))
+
+    def with_slicing(u):
+        m = u.reshape(4, 2)
+        a, b = (m[:2], m[2:]) if axis == 0 else (m[:, :1], m[:, 1:])
+        return jnp.sum(a * b) + jnp.sum(jnp.sin(a))
+
+    pat = pattern_from_energy(with_split, n)
+    traced = nz_set(pat)
+    assert traced == nz_set(pattern_from_energy(with_slicing, n))  # rows routed identically
+    assert dense_hessian_pattern(with_split, n) <= traced  # no false negatives
+    assert traced == nz_set(pat.T)  # structural symmetry
+    assert pat.nnz < n * n  # locality: never the dense fallback block
+
+
+def test_split_uses_handler_not_generic_fallback():
+    """``split`` must be *handled*, not silently over-approximated: the generic fallback
+    warns, so an energy containing a ``split`` on an active path must emit no warning.
+    Guards against the handler being dropped or the primitive being renamed upstream.
+    """
+
+    def energy(u):
+        return sum(jnp.sum(p**2) for p in jnp.split(u, 2))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any fallback UserWarning becomes a failure
+        pat = pattern_from_energy(energy, 4)
+
+    # exact here: split is structural, so **2 couples each DOF only with itself
+    assert nz_set(pat) == {(i, i) for i in range(4)}
+
+
 def test_eigh_is_dense_nonlinear_no_false_negatives():
     """``jnp.linalg.eigh`` (→ ``eigh``) is a dense nonlinear op: every eigenvalue depends on
     the whole matrix, so consuming it — even linearly — must record the full block. Covers


### PR DESCRIPTION
**Related Issue**
None

**Description of Changes**

- **make_interpolate:** this adds a new method `op.make_interpolate(points)` that returns an interpolation function for a fixed set of points. This is needed to do the element search once before the main computations. `op.interpolate(...)` still works the same but uses `make_interpolate` under the hood now.
- **add jnp.split primitive to tracer:** added the primitive to the handled expressions in the sparsity tracer. This primitive is linear and does not affect the sparsity.

**Checklist:**
- [x] I have read the contributing guidelines.
- [x] My code follows the style guidelines of this project. `tatva` uses `ruff`.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have commented my code, particularly in hard-to-understand areas.
